### PR TITLE
Add example OPA tests and GHA workflow

### DIFF
--- a/.github/workflows/run-policy-tests.yaml
+++ b/.github/workflows/run-policy-tests.yaml
@@ -1,0 +1,22 @@
+name: Run Policy Tests
+
+on: { push: { branches-ignore: [main] } }
+
+jobs:
+  unit-testing:
+    name: Run OPA Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@master
+
+      - name: Download OPA
+        run: |
+          curl -L -o /tmp/opa https://openpolicyagent.org/downloads/v0.29.4/opa_linux_amd64
+          chmod u+x /tmp/opa
+
+      - name: Run Tests
+        run: ./run_policy_tests.sh
+        env:
+          OPA_PATH: "/tmp/opa"

--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ Policy Types Currently In This Library are below. Feel free to click on a given 
 | [PLAN](./plan)  | [Enforce Tags on Resources](./plan/enforce-tags-on-resources.rego) |
 | [PLAN](./plan)  | [Infracost Monthly Cost Restriction](./plan/infracost-monthly-cost-restriction.rego) |
 | [TRIGGER](./trigger)  | [Trigger Dependencies](./trigger/trigger-dependencies.rego) |
+
+## Policy Tests
+
+Tests can be added for policies using the convention `<policy_filename>_test.rego`. For example
+if you have a policy called `plan.rego`, you can create a test file called `plan_test.rego`.
+
+You can use the following command to run all policy tests:
+
+```shell
+./run_policy_tests.sh
+```

--- a/git-push/ignore-changes-outside-root_test.rego
+++ b/git-push/ignore-changes-outside-root_test.rego
@@ -1,0 +1,97 @@
+package spacelift
+
+test_affected_no_files {
+    not affected with input as {
+        "stack": {
+            "project_root": ""
+        },
+        "push": {
+            "affected_files": []
+        }
+    }
+}
+
+test_affected_tf_files {
+    affected with input as {
+        "stack": {
+            "project_root": ""
+        },
+        "push": {
+            "affected_files": ["main.tf", "stacks.tf"]
+        }
+    }
+}
+
+test_affected_no_tf_files {
+    not affected with input as {
+        "stack": {
+            "project_root": ""
+        },
+        "push": {
+            "affected_files": ["README", "myicon.png"]
+        }
+    }
+}
+
+test_affected_outside_project_root {
+    not affected with input as {
+        "stack": {
+            "project_root": "stacks/my-stack"
+        },
+        "push": {
+            "affected_files": ["stacks/another-stack/main.tf"]
+        }
+    }
+}
+
+test_ignore_affected {
+    ignore with affected as false
+}
+
+test_ignore_not_affected {
+    not ignore with affected as true
+}
+
+test_ignore_tag {
+    ignore with input as {
+        "push": {
+            "tag": "v1.0.0"
+        }
+    } with affected as true
+}
+
+test_propose_affected {
+    propose with affected as true
+}
+
+test_propose_not_affected {
+    not propose with affected as false
+}
+
+matching_branch_input = {
+        "push": {
+            "branch": "main"
+        },
+        "stack": {
+            "branch": "main"
+        }
+    }
+
+test_track_affected {
+    track with input as matching_branch_input with affected as true
+}
+
+test_track_not_affected {
+    not track with input as matching_branch_input with affected as false
+}
+
+test_track_not_stack_branch {
+    not track with input as {
+        "push": {
+            "branch": "my-feature"
+        },
+        "stack": {
+            "branch": "main"
+        }
+    } with affected as true
+}

--- a/run_policy_tests.sh
+++ b/run_policy_tests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+if [ -z $OPA_PATH ]; then
+    OPA_PATH=opa
+fi
+
+tests=$(find . -type f -regex ".*_test\.rego")
+
+# OPA doesn't like it if multiple rego files define the same rules, so iterate over
+# all the test files and run `opa test` separately.
+for test_file in $tests; do
+    target="${test_file/_test.rego/.rego}"
+
+    echo "Testing $target with $test_file"
+    $OPA_PATH test $test_file $target -v
+done
+
+echo "Tests OK"


### PR DESCRIPTION
I've added a script that can find any tests and run them, along with a GitHub Actions workflow. The reason for using the `_test.rego` naming scheme rather than just running `opa test .` is that we define the same rules in separate policies, and `opa test` can't handle that.