### PR TITLE
FEATURE - Add example for allowing only safe task commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Policy Types Currently In This Library are below. Feel free to click on a given 
 | [PUSH](./push/)  |
 | [LOGIN](./login)  |
 | [PLAN](./plan)  |
+| [TASK](./task)  |
 | [TRIGGER](./trigger)  |
 
 ## All Policy Examples
@@ -37,6 +38,7 @@ Policy Types Currently In This Library are below. Feel free to click on a given 
 | [PLAN](./plan)  | [Enforce Password Strength](./plan/enforce-password-length.rego) |
 | [PLAN](./plan)  | [Enforce Tags on Resources](./plan/enforce-tags-on-resources.rego) |
 | [PLAN](./plan)  | [Infracost Monthly Cost Restriction](./plan/infracost-monthly-cost-restriction.rego) |
+| [TASK](./task)  | [Allow Only Safe Task Commands](./trigger/allow-only-safe-commands.rego) |
 | [TRIGGER](./trigger)  | [Trigger Dependencies](./trigger/trigger-dependencies.rego) |
 
 ## Policy Tests

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Policy Types Currently In This Library are below. Feel free to click on a given 
 | [PLAN](./plan)  | [Enforce Password Strength](./plan/enforce-password-length.rego) |
 | [PLAN](./plan)  | [Enforce Tags on Resources](./plan/enforce-tags-on-resources.rego) |
 | [PLAN](./plan)  | [Infracost Monthly Cost Restriction](./plan/infracost-monthly-cost-restriction.rego) |
-| [TASK](./task)  | [Allow Only Safe Task Commands](./trigger/allow-only-safe-commands.rego) |
+| [TASK](./task)  | [Allow Only Safe Task Commands](./task/allow-only-safe-commands.rego) |
 | [TRIGGER](./trigger)  | [Trigger Dependencies](./trigger/trigger-dependencies.rego) |
 
 ## Policy Tests

--- a/task/README.md
+++ b/task/README.md
@@ -1,0 +1,5 @@
+# Spacelift Task Policy Examples
+
+For more information on writing Task Policies and their usage, please refer to the Spacelift documentation:
+
+[https://docs.spacelift.io/concepts/policy/task-run-policy](https://docs.spacelift.io/concepts/policy/task-run-policy)

--- a/task/allow-only-safe-commands.rego
+++ b/task/allow-only-safe-commands.rego
@@ -1,0 +1,20 @@
+package spacelift
+
+# This task policy only allows you to exectute a few selected commands.
+#
+# You can read more about task policies here:
+#
+# https://docs.spacelift.io/concepts/policy/task-run-policy
+
+allowlist := {
+    "ls",
+    "terraform taint random_password.secret",
+}
+
+allowed { allowlist[_] == input.request.command }
+deny["Only selected commands are allowed"] { not allowed }
+
+# Learn more about sampling policy evaluations here:
+#
+# https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
+sample { true }


### PR DESCRIPTION
# What's in this PR
* Add example for allowing only safe task commands