### PR TITLE
Access: Tag Based Team Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Policy Types Currently In This Library are below. Feel free to click on a given 
 | [ACCESS](./access/)  | [Protect Administrative Stacks](./access/protect-administrative-stacks.rego) |
 | [ACCESS](./access/)  | [Slack Channel Access](./access/slack-channel-access.rego) |
 | [ACCESS](./access/)  | [Who When Where Access Restrictions](./access/who-when-where-access-restrictions.rego) |
+| [ACCESS](./access/)  | [Tag Based Team Access](./access/tag-based-team-access.rego) |
 | [APPROVAL](./approval)  | [Allowlist Task Commands](./approval/allowlist-task-commands.rego) |
 | [APPROVAL](./approval)  | [Multi Team Required Approvals](./approval/multi-team-required-approvals.rego) |
 | [APPROVAL](./approval)  | [Reject runs on public workers](./approval/reject-runs-on-public-workers.rego) |

--- a/access/tag-based-team-access.rego
+++ b/access/tag-based-team-access.rego
@@ -1,0 +1,40 @@
+package spacelift
+import future.keywords.if
+import future.keywords.in
+
+# This policy allow you to tag a repo with a "access:<level>:<team>" tag to
+#  grant access to Stacks via labels.
+
+
+# In lieu of rego not yet having a regex.replace this does the friendly name to
+#   GitHub ID sanitization
+# "My_Team is - awesome" -> "myr_-team-is-awesome"`
+trim_whitespace(s) := concat("-", parts) {
+	parts := [lower(part) |
+		some part in split(s, " ")
+		not part in {"-"}
+	]
+}
+# Convert all Teams to the ID format
+teams := { x | x := trim_whitespace(input.session.teams[_]) }
+# Find access pattern matching labels and return just "access:team" for each
+labels := { trim_prefix(label, "access:") |
+	some label in input.stack.labels
+	not label == ""
+	regex.match("^access:(read|write|deny):[^:]+$", label)
+}
+# check if any team would allow request "access" level
+test(access) if {
+	some team in teams
+	labels[concat(":", [access, team])]
+}
+
+deny := test("deny")
+write := test("write")
+read := test("read")
+
+# Never allow write access to administrative stacks
+deny_write { input.stack.administrative }
+
+# Turn on input sampling for all attempts
+sample { true }

--- a/access/tag-based-team-access_test.rego
+++ b/access/tag-based-team-access_test.rego
@@ -1,0 +1,91 @@
+package spacelift
+
+# in most cases read/write/deny act exactly the same, so tests
+#   will only focus on specifics for those when it applies
+
+test_no_denywrite_if_nothing {
+    not deny_write with input as {
+        "session": { "teams": [ ] },
+        "stack": { "labels": [ ] }
+    }
+}
+
+test_denywrite_if_administrative {
+    deny_write with input as {
+        "session": { "teams": [ ] },
+        "stack": {
+            "administrative": true,
+            "labels": [ ]
+        }
+    }
+}
+
+test_no_write_if_nothing {
+    not write with input as {
+        "session": { "teams": [ ] },
+        "stack": { "labels": [ ] }
+    }
+}
+
+test_no_write_if_label {
+    not write with input as {
+        "session": { "teams": [ ] },
+        "stack": { "labels": ["access:write:my-team"] }
+    }
+}
+
+test_no_write_if_wrong_team {
+    not write with input as {
+        "session": { "teams": ["My_Team"] },
+        "stack": { "labels": ["access:write:my-team"] }
+    }
+}
+
+test_write_if_correct_team {
+     write with input as {
+        "session": { "teams": ["My Team"] },
+        "stack": { "labels": ["access:write:my-team"] }
+    }
+}
+
+test_write_if_correct_team2 {
+     write with input as {
+        "session": { "teams": ["My - Team"] },
+        "stack": { "labels": ["access:write:my-team"] }
+    }
+}
+
+test_no_write_if_wrong_level {
+     not write with input as {
+        "session": { "teams": ["My - Team"] },
+        "stack": { "labels": ["access:read:my-team"] }
+    }
+}
+
+test_no_write_if_wrong_wrong_label {
+     not write with input as {
+        "session": { "teams": ["My - Team"] },
+        "stack": { "labels": ["access:write:*"] }
+    }
+}
+
+test_no_write_if_wrong_wrong_label2 {
+     not write with input as {
+        "session": { "teams": ["My - Team"] },
+        "stack": { "labels": ["write"] }
+    }
+}
+
+test_no_write_if_wrong_wrong_label3 {
+     not write with input as {
+        "session": { "teams": ["My - Team"] },
+        "stack": { "labels": ["write:my-team"] }
+    }
+}
+
+test_no_write_if_wrong_wrong_label4 {
+     not write with input as {
+        "session": { "teams": ["My - Team"] },
+        "stack": { "labels": ["access:write:my-team"] }
+    }
+}

--- a/access/tag-based-team-access_test.rego
+++ b/access/tag-based-team-access_test.rego
@@ -86,6 +86,6 @@ test_no_write_if_wrong_wrong_label3 {
 test_no_write_if_wrong_wrong_label4 {
      not write with input as {
         "session": { "teams": ["My - Team"] },
-        "stack": { "labels": ["access:write:my-team"] }
+        "stack": { "labels": ["access:write:my-team:haha"] }
     }
 }


### PR DESCRIPTION
Use labels to grant access to stacks.  This maps against GitHub's Team "ID format", as opposed to the friendly team name.  The policy also denies write access to any administrative stack.

Friendly Name: `My Team_Is Awesome`
ID: `my-team_is-awesome`

### Label Format

`access:<level>:<team-id>`

level can be: read, write, deny

### Example

In this scenario a user would be granted write access to the stack, because the team matches the label assignment.

```rego
{
  "session": { "teams": ["My Team"] },
  "stack": { "labels": ["access:write:my-team"] }
}
```
