### PR TITLE
Use tags_all rather than tags

### DIFF
--- a/plan/enforce-tags-on-resources.rego
+++ b/plan/enforce-tags-on-resources.rego
@@ -9,7 +9,7 @@ required_tags := {"Name", "env", "owner"}
 
 deny[sprintf("resource %q does not have all suggested tags (%s)", [resource.address, concat(", ", missing_tags)])] {
 	resource := input.terraform.resource_changes[_]
-	tags := resource.change.after.tags
+	tags := resource.change.after.tags_all
 
 	missing_tags := {tag | required_tags[tag]; not tags[tag]}
 


### PR DESCRIPTION
tags_all was added in recent versions of the aws terraform provider to contain both tags defined at the resource level and at the provider level. The historical `tags` attribute only contains tags defined at the resource level.

Updating to use `tags_all` will cause tags which are defined at the provider level to be considered.

[aws provider default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider)
https://stackoverflow.com/a/71644060