### PR TITLE
Fix tag evaluation. Terraform passes the data as tags not tags_all

### DIFF
--- a/plan/enforce-tags-on-resources.rego
+++ b/plan/enforce-tags-on-resources.rego
@@ -9,7 +9,7 @@ required_tags := {"Name", "env", "owner"}
 
 deny[sprintf("resource %q does not have all suggested tags (%s)", [resource.address, concat(", ", missing_tags)])] {
 	resource := input.terraform.resource_changes[_]
-	tags := resource.change.after.tags_all
+	tags := resource.change.after.tags
 
 	missing_tags := {tag | required_tags[tag]; not tags[tag]}
 


### PR DESCRIPTION
Running the enforce-tags-on-resources policy failed as the key `tags_all` was not in the input data.
Changing the key to evaluate to `tags` works.