### PR TITLE
Add Regal for linting

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -7,26 +7,17 @@ on:
   pull_request:
 
 jobs:
-  formatting-check:
-    name: Formatting Check
+  regal-check:
+    name: Regal Check
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out
-        uses: actions/checkout@v3
-
-      - name: Install OPA
-        uses: open-policy-agent/setup-opa@v2
+      - uses: actions/checkout@v3
+      - name: Setup Regal
+        uses: StyraInc/setup-regal@v0.2.0
         with:
-          version: 0.51.0
-
-      - name: Check formatting
-        run: |
-          output="$(opa fmt --diff .)"
-          if [ -n "$output" ]; then
-              echo "$output"
-              exit 1
-          fi
+          version: v0.11.0
+      - run: regal lint --format=github .
 
   syntax-check:
     name: Syntax Check
@@ -46,7 +37,7 @@ jobs:
           # KLUDGE: plan/check-sanitized-value.rego needs to be ignored because it uses the custom sanitized() function
           policies=$(find . -type f -regex '.*\.rego$' | grep -v _test.rego | grep -v plan/check-sanitized-value.rego)
           for policy in $policies; do
-              opa check $policy
+              opa check --strict $policy
           done
 
   unit-tests:

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,22 @@
+rules:
+  idiomatic:
+    no-defined-entrypoint:
+      level: ignore
+  style:
+    external-reference:
+      level: ignore
+    line-length:
+      level: ignore
+    prefer-some-in-iteration:
+      level: ignore
+    todo-comment:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      level: ignore
+
+capabilities:
+  from:
+    # Feel free to submit a PR to have "spacelift" added as an engine!
+    engine: opa
+    version: v0.51.0

--- a/access/downgrade-access-after-hours.rego
+++ b/access/downgrade-access-after-hours.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # When things go wrong it's usually because someone did something, like an infra deployment.
 # Let's try to make sure they're in the office when doing so and restrict write access to business hours
 # and office IP range.
@@ -17,7 +19,7 @@ weekday := time.weekday(now)
 ip := input.request.remote_ip
 
 write {
-	input.session.teams[_] == "Product team"
+	"Product team" in input.session.teams
 }
 
 deny_write {

--- a/access/engineering-team-access.rego
+++ b/access/engineering-team-access.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # This example access policy gives everyone in the "Engineering" GitHub team
 # read access to the stack.
 #
@@ -7,9 +9,9 @@ package spacelift
 # https://docs.spacelift.io/concepts/policy/stack-access-policy
 
 read {
-	input.session.teams[_] == "Engineering"
+	"Engineering" in input.session.teams
 }
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/access/label-based-team-access.rego
+++ b/access/label-based-team-access.rego
@@ -17,13 +17,13 @@ trim_whitespace(s) := concat("-", parts) if {
 }
 
 # Convert all Teams to the ID format
-teams := {x | x := trim_whitespace(input.session.teams[_])}
+teams[trim_whitespace(input.session.teams[_])]
 
 # Find access pattern matching labels and return just "access:team" for each
-labels := {trim_prefix(label, "access:") |
+labels[trim_prefix(label, "access:")] {
 	some label in input.stack.labels
 	not label == ""
-	regex.match("^access:(read|write|deny):[^:]+$", label)
+	regex.match(`^access:(read|write|deny):[^:]+$`, label)
 }
 
 # check if any team would allow request "access" level
@@ -42,4 +42,4 @@ read := test("read")
 deny_write if input.stack.administrative
 
 # Turn on input sampling for all attempts
-sample = true
+sample := true

--- a/access/protect-administrative-stacks.rego
+++ b/access/protect-administrative-stacks.rego
@@ -1,8 +1,8 @@
 package spacelift
 
-# Administrative stacks are powerful - getting write access to one is almost 
-# as good as being an admin - you can define and attach contexts and policies. 
-# So let's deny write access to them entirely. This works since access policies 
+# Administrative stacks are powerful - getting write access to one is almost
+# as good as being an admin - you can define and attach contexts and policies.
+# So let's deny write access to them entirely. This works since access policies
 # are not evaluated for admin users.
 
 deny_write {
@@ -11,4 +11,4 @@ deny_write {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/access/slack-channel-access.rego
+++ b/access/slack-channel-access.rego
@@ -4,7 +4,7 @@ package spacelift
 # attach this policy to a given stack, and this would provide
 # the Slack Channel "dev-notifications" access to your Spacelift
 # stack's data.
-# 
+#
 # NOTE: If you are looking to scope access to individual Slack channels
 # you should consider using the channel id, rather than the name, as names can change.
 write {
@@ -13,4 +13,4 @@ write {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/access/who-when-where-access-restrictions.rego
+++ b/access/who-when-where-access-restrictions.rego
@@ -1,10 +1,12 @@
 package spacelift
 
+import future.keywords.in
+
 # In case things go wrong, we want you to be there.
 #
-# You know when things go wrong it's usually because someone did something. 
-# Like an infra deployment. Let's try to make sure they're in the office 
-# when doing so and restrict write access to business hours and office IP range. 
+# You know when things go wrong it's usually because someone did something.
+# Like an infra deployment. Let's try to make sure they're in the office
+# when doing so and restrict write access to business hours and office IP range.
 # This policy is best combined with one that gives read access.
 
 # Let's set some variables we can reference later
@@ -20,10 +22,10 @@ ip := input.request.remote_ip
 
 # Now let's define use those above variables to define the criteria
 # for who can have write access, when, and from where (the ip)
-# 
+#
 # Allow write access from the Product team
 write {
-	input.session.teams[_] == "Product team"
+	"Product team" in input.session.teams
 }
 
 # Only allow access during weekdays
@@ -47,4 +49,4 @@ deny_write {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/allowlist-task-commands.rego
+++ b/approval/allowlist-task-commands.rego
@@ -20,4 +20,4 @@ approve {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/approval-outside-working-hours.rego
+++ b/approval/approval-outside-working-hours.rego
@@ -37,4 +37,4 @@ reject {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/approval-outside-working-hours_test.rego
+++ b/approval/approval-outside-working-hours_test.rego
@@ -9,63 +9,56 @@ mock_created_at_weekend := 1692477510000000000
 
 # Test automatic approval for a weekday between 9am to 5pm
 test_automatic_approve_weekday_morning {
-	input := {
+	approve with input as {
 		"run": {"created_at": mock_created_at_weekday_morning},
 		"reviews": {"current": {"approvals": [], "rejections": []}},
 	}
-	approve with input as input
 }
 
 # Test required approval for a weekday after 5pm
 test_required_approval_weekday_evening {
-	input := {
+	approve with input as {
 		"run": {"created_at": mock_created_at_weekday_evening},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": []}},
 	}
-	approve with input as input
 }
 
 # Test missing approval for a weekday after 5pm
 test_missing_approval_weekday_evening {
-	input := {
+	not approve with input as {
 		"run": {"created_at": mock_created_at_weekday_evening},
 		"reviews": {"current": {"approvals": [], "rejections": []}},
 	}
-	not approve with input as input
 }
 
 # Test required approval during weekend
 test_required_approval_weekend {
-	input := {
+	approve with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": []}},
 	}
-	approve with input as input
 }
 
 # Test missing approval during weekend
 test_missing_approval_weekend {
-	input := {
+	not approve with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": [], "rejections": []}},
 	}
-	not approve with input as input
 }
 
 # Test reject due to a rejection review
 test_rejection_due_to_review {
-	input := {
+	reject with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": ["user2"]}},
 	}
-	reject with input as input
 }
 
 # Test no rejection when there's no rejection review
 test_no_rejection_when_no_review {
-	input := {
+	not reject with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": []}},
 	}
-	not reject with input as input
 }

--- a/approval/require-approval-from-security-team.rego
+++ b/approval/require-approval-from-security-team.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # This policy approves any runs when someone from Security team approves the changes to the resources in the list,
 # and rejects any runs when someone from other teams tries to approve the changes.
 
@@ -10,7 +12,7 @@ approve {
 	input.run.state != "UNCONFIRMED"
 }
 
-approval_list = [
+approval_list := [
 	"aws_iam_access_key",
 	"aws_security_group",
 	"aws_security_group_rule",
@@ -54,7 +56,7 @@ approvals := input.reviews.current.approvals
 
 # Let's define what it means to be approved by Security team.
 security_approval {
-	approvals[_].session.teams[_] == "Security"
+	"Security" in approvals[_].session.teams
 }
 
 # Approve when Security team approve and Require at least 1 approval:
@@ -70,4 +72,4 @@ reject {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/require-private-worker.rego
+++ b/approval/require-private-worker.rego
@@ -19,4 +19,4 @@ reject {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/role-based-approval.rego
+++ b/approval/role-based-approval.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # First, let's define all conditions that require explicit
 # user approval.
 requires_approval {
@@ -18,15 +20,15 @@ approvals := input.reviews.current.approvals
 
 # Let's define what it means to be approved by a director, DevOps amd Security.
 director_approval {
-	approvals[_].session.teams[_] == "Director"
+	"Director" in approvals[_].session.teams
 }
 
 devops_approval {
-	approvals[_].session.teams[_] == "DevOps"
+	"DevOps" in approvals[_].session.teams
 }
 
 security_approval {
-	approvals[_].session.teams[_] == "Security"
+	"Security" in approvals[_].session.teams
 }
 
 # Approve when a single director approves:
@@ -42,4 +44,4 @@ approve {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/task-and-run-approvals.rego
+++ b/approval/task-and-run-approvals.rego
@@ -31,4 +31,4 @@ approve {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/two-approvals-no-rejections.rego
+++ b/approval/two-approvals-no-rejections.rego
@@ -1,8 +1,8 @@
 package spacelift
 
-# In this example, each Unconfirmed run will require two approvals - 
-# including proposed runs triggered by Git events. Additionally, 
-# the run should have no rejections. Anyone who rejects the run will 
+# In this example, each Unconfirmed run will require two approvals -
+# including proposed runs triggered by Git events. Additionally,
+# the run should have no rejections. Anyone who rejects the run will
 # need to change their mind in order for the run to go through.
 
 approve {
@@ -16,4 +16,4 @@ approve {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/approval/two-approvals-two-rejections.rego
+++ b/approval/two-approvals-two-rejections.rego
@@ -19,4 +19,4 @@ reject {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/login/access-levels-within-an-organization.rego
+++ b/login/access-levels-within-an-organization.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # This login policy gives everyone in the organization access to Spacelift
 # and makes all members of the "DevOps" team admins.
 #
@@ -7,7 +9,7 @@ package spacelift
 # https://docs.spacelift.io/concepts/policy/login-policy
 
 admin {
-	input.session.teams[_] == "DevOps"
+	"DevOps" in input.session.teams
 }
 
 allow {
@@ -20,4 +22,4 @@ deny {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/login/external-contributor-access-github.rego
+++ b/login/external-contributor-access-github.rego
@@ -1,10 +1,10 @@
 package spacelift
 
-# NOTE: This feature is not available when using single sign-on - 
-# your identity provider must be able to successfully validate each user 
+# NOTE: This feature is not available when using single sign-on -
+# your identity provider must be able to successfully validate each user
 # trying to log in to Spacelift.
 
-# Sometimes you have folks (short-term consultants, most likely) who are 
+# Sometimes you have folks (short-term consultants, most likely) who are
 # not members of your organization but need access to your Spacelift account -
 # either as regular members or perhaps even as admins. There's also the situation
 # where a bunch of friends is working on a hobby project in a personal GitHub account
@@ -32,4 +32,4 @@ deny {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/login/external-contributor-access-google.rego
+++ b/login/external-contributor-access-google.rego
@@ -28,4 +28,4 @@ deny {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/login/rewriting-user-teams.rego
+++ b/login/rewriting-user-teams.rego
@@ -1,10 +1,10 @@
 package spacelift
 
+import future.keywords.in
+
 # This rule will copy each of the existing teams to the new modified list.
 # Remove it if you want to start from scratch.
-team[name] {
-	name := input.session.teams[_]
-}
+team[input.session.teams[_]]
 
 # In addition to boolean rules regulating access to your Spacelift account, the login
 # policy exposes the team rule, which allows one to dynamically rewrite the list of teams
@@ -22,11 +22,11 @@ team["Superwriter"] {
 }
 
 contractor {
-	input.session.teams[_] == "Contractors"
+	"Contractors" in input.session.teams
 }
 
 devops {
-	input.session.teams[_] == "DevOps"
+	"DevOps" in input.session.teams
 }
 
 office_vpn {
@@ -40,4 +40,4 @@ office_vpn {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/login/who-when-where-login-restrictions.rego
+++ b/login/who-when-where-login-restrictions.rego
@@ -1,7 +1,7 @@
 package spacelift
 
-# The example below is pretty extreme but it shows a very comprehensive 
-# policy where you restrict Spacelift access to users logging in from the office IP 
+# The example below is pretty extreme but it shows a very comprehensive
+# policy where you restrict Spacelift access to users logging in from the office IP
 # during business hours. You may want to use elements of this policy to create your own
 # - less draconian - version, or keep it this way to support everyone's work-life balance.
 
@@ -18,7 +18,7 @@ ip := input.request.remote_ip
 
 # Now let's define use those above variables to define the criteria
 # for who can have write access, when, and from where (the ip)
-# 
+#
 # Only allow access during weekdays
 deny {
 	weekend[weekday]
@@ -40,4 +40,4 @@ deny {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/notification/drift-detection-with-changes.rego
+++ b/notification/drift-detection-with-changes.rego
@@ -8,4 +8,4 @@ slack[{"channel_id": "C000000"}] {
 	count(input.run_updated.run.changes) > 0
 }
 
-sample = true
+sample := true

--- a/notification/drift-detection-with-changes_test.rego
+++ b/notification/drift-detection-with-changes_test.rego
@@ -2,36 +2,32 @@ package spacelift
 
 # Test when drift detection is present and there's at least one change
 test_slack_trigger_for_drift_and_changes {
-	input := {"run_updated": {"run": {
+	count(slack) == 1 with input as {"run_updated": {"run": {
 		"drift_detection": true,
 		"changes": [{"change": "example_change_1"}],
 	}}}
-	count(slack) == 1 with input as input
 }
 
 # Test when drift detection is not present but there's at least one change
 test_no_slack_trigger_for_no_drift_but_changes {
-	input := {"run_updated": {"run": {
+	count(slack) == 0 with input as {"run_updated": {"run": {
 		"drift_detection": false,
 		"changes": [{"change": "example_change_1"}],
 	}}}
-	count(slack) == 0 with input as input
 }
 
 # Test when drift detection is present but there are no changes
 test_no_slack_trigger_for_drift_but_no_changes {
-	input := {"run_updated": {"run": {
+	count(slack) == 0 with input as {"run_updated": {"run": {
 		"drift_detection": true,
 		"changes": [],
 	}}}
-	count(slack) == 0 with input as input
 }
 
 # Test when both drift detection isn't present and there are no changes
 test_no_slack_trigger_for_no_drift_and_no_changes {
-	input := {"run_updated": {"run": {
+	count(slack) == 0 with input as {"run_updated": {"run": {
 		"drift_detection": false,
 		"changes": [],
 	}}}
-	count(slack) == 0 with input as input
 }

--- a/notification/slack-channels-with-labels.rego
+++ b/notification/slack-channels-with-labels.rego
@@ -16,9 +16,9 @@ slack[{"channel_id": channel}] {
 	run := input.run_updated.run
 	run.type == "TRACKED"
 
-	# Here we're using the slack_channels rule to get all channels 
+	# Here we're using the slack_channels rule to get all channels
 	# and iterate over each one.
 	channel = slack_channels[_]
 }
 
-sample = true
+sample := true

--- a/notification/slack-channels-with-labels_test.rego
+++ b/notification/slack-channels-with-labels_test.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # 1. Label with the right format triggers slack rule
 test_single_label_triggers_slack {
 	result := slack with input as {"run_updated": {
@@ -7,7 +9,7 @@ test_single_label_triggers_slack {
 		"run": {"type": "TRACKED"},
 	}}
 	count(result) == 1
-	result[_] == {"channel_id": "C12345678"}
+	{"channel_id": "C12345678"} in result
 }
 
 # 2. Two labels in the right format should trigger slack rule twice
@@ -20,8 +22,8 @@ test_two_labels_trigger_slack_twice {
 		"run": {"type": "TRACKED"},
 	}}
 	count(result) == 2
-	result[_] == {"channel_id": "C12345678"}
-	result[_] == {"channel_id": "C89101112"}
+	{"channel_id": "C12345678"} in result
+	{"channel_id": "C89101112"} in result
 }
 
 # 3. Label not in the right format should not trigger slack rule

--- a/plan/check-blast-radius.rego
+++ b/plan/check-blast-radius.rego
@@ -27,7 +27,7 @@ blast_radius_too_high[sprintf("change blast radius too high (%d/100)", [blast_ra
 	blast_radius > 100
 }
 
-blast_radius_for_resource(resource) = ret {
+blast_radius_for_resource(resource) := ret {
 	blasts_radii_by_action := {"delete": 10, "update": 5, "create": 1, "no-op": 0}
 
 	ret := sum([value |
@@ -42,10 +42,8 @@ blast_radius_for_resource(resource) = ret {
 blasts_radii_by_type := {"aws_ecs_cluster": 20, "aws_ecs_user": 10, "aws_ecs_role": 5}
 
 # By default, blast radius has a value of 1.
-blast_radius_for_type(type) = 1 {
+blast_radius_for_type(type) := 1 {
 	not blasts_radii_by_type[type]
 }
 
-blast_radius_for_type(type) = ret {
-	blasts_radii_by_type[type] = ret
-}
+blast_radius_for_type(type) := blasts_radii_by_type[type]

--- a/plan/checkov-failed-checks.rego
+++ b/plan/checkov-failed-checks.rego
@@ -11,7 +11,7 @@ warn[sprintf(message, [p])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true
 
-# Learn more about how to integrate custom inputs here: 
+# Learn more about how to integrate custom inputs here:
 # https://spacelift.io/blog/integrating-security-tools-with-spacelift

--- a/plan/deny-proposed-runs-warn-track-runs.rego
+++ b/plan/deny-proposed-runs-warn-track-runs.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # The best way to use warn and deny rules together depends on your preferred Git workflow.
 # We've found short-lived feature branches with Pull Requests to the tracked branch to work relatively well.
 # In this scenario, the `type` of the `run` is important - it's _PROPOSED_ for commits to feature branches,
@@ -32,11 +34,11 @@ warn[reason] {
 
 iam_user_created[sprintf("Do not create IAM users: (%s)", [resource.address])] {
 	resource := input.terraform.resource_changes[_]
-	resource.change.actions[_] == "create"
+	"create" in resource.change.actions
 
 	resource.type == "aws_iam_user"
 }
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/do-not-delete-stateful-resources.rego
+++ b/plan/do-not-delete-stateful-resources.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # This policy is a plan policy, it will validate the resources during the plan phase.
 # More details at: https://docs.spacelift.io/concepts/policy/terraform-plan-policy
 # The "deny" rule fires when a specified resource is being deleted.
@@ -24,9 +26,9 @@ deny[sprintf(message, [resource.address])] {
 	prevent_delete[resource.type]
 
 	# Check if any of the actions on the resource is "delete"
-	resource.change.actions[_] == "delete"
+	"delete" in resource.change.actions
 }
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/do-not-delete-stateful-resources_test.rego
+++ b/plan/do-not-delete-stateful-resources_test.rego
@@ -2,69 +2,50 @@ package spacelift
 
 # Test case for an aws_s3_bucket being deleted
 test_deny_s3_bucket_deletion {
-	# Provide mock input data
-	input := {"terraform": {"resource_changes": [{
+	# Assert deny rule fires with the expected message
+	deny["do not delete aws_s3_bucket.my_bucket"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_s3_bucket.my_bucket",
 		"type": "aws_s3_bucket",
 		"change": {"actions": ["delete"]},
 	}]}}
-
-	# Assert deny rule fires with the expected message
-	deny[msg] with input as input
-	msg == "do not delete aws_s3_bucket.my_bucket"
 }
 
 # Test case for an aws_db_instance being deleted
 test_deny_db_instance_deletion {
-	# Provide mock input data
-	input := {"terraform": {"resource_changes": [{
+	# Assert deny rule fires with the expected message
+	deny["do not delete aws_db_instance.my_rds"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_db_instance.my_rds",
 		"type": "aws_db_instance",
 		"change": {"actions": ["delete"]},
 	}]}}
-
-	# Assert deny rule fires with the expected message
-	deny[msg] with input as input
-	msg == "do not delete aws_db_instance.my_rds"
 }
 
 # Test case for an aws_efs_file_system being deleted
 test_deny_efs_file_system_deletion {
-	# Provide mock input data
-	input := {"terraform": {"resource_changes": [{
+	# Assert deny rule fires with the expected message
+	deny["do not delete aws_efs_file_system.my_efs"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_efs_file_system.my_efs",
 		"type": "aws_efs_file_system",
 		"change": {"actions": ["delete"]},
 	}]}}
-
-	# Assert deny rule fires with the expected message
-	deny[msg] with input as input
-	msg == "do not delete aws_efs_file_system.my_efs"
 }
 
 # Test case for an aws_dynamodb_table being deleted
 test_deny_dynamodb_table_deletion {
-	# Provide mock input data
-	input := {"terraform": {"resource_changes": [{
+	# Assert deny rule fires with the expected message
+	deny["do not delete aws_dynamodb_table.my_table"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_dynamodb_table.my_table",
 		"type": "aws_dynamodb_table",
 		"change": {"actions": ["delete"]},
 	}]}}
-
-	# Assert deny rule fires with the expected message
-	deny[msg] with input as input
-	msg == "do not delete aws_dynamodb_table.my_table"
 }
 
 # Test case for an aws_instance being deleted (which should not be denied)
 test_allow_instance_deletion {
-	# Provide mock input data
-	input := {"terraform": {"resource_changes": [{
+	# Assert deny rule does not fire
+	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_instance.my_instance",
 		"type": "aws_instance",
 		"change": {"actions": ["delete"]},
 	}]}}
-
-	# Assert deny rule does not fire
-	count(deny) == 0 with input as input
 }

--- a/plan/dont-allow-resource-type.rego
+++ b/plan/dont-allow-resource-type.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # Note that the message here is dynamic and captures resource address to provide
 # appropriate context to anyone affected by this policy. For the sake of your
 # sanity and that of your colleagues, please a
@@ -11,7 +13,7 @@ deny[sprintf(message, [resource.address])] {
 	message := "Static AWS credentials are evil (%s)"
 
 	resource := input.terraform.resource_changes[_]
-	resource.change.actions[_] == "create"
+	"create" in resource.change.actions
 
 	# This is what decides whether the rule captures a resource.
 	# There may be an arbitrary number of conditions, and they all must
@@ -21,4 +23,4 @@ deny[sprintf(message, [resource.address])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/enforce-cloud-provider.rego
+++ b/plan/enforce-cloud-provider.rego
@@ -16,4 +16,4 @@ deny[sprintf(message, [resource.address])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/enforce-instance-type-list.rego
+++ b/plan/enforce-instance-type-list.rego
@@ -44,4 +44,4 @@ is_in_deny_list(instance) {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/enforce-instance-type-list_test.rego
+++ b/plan/enforce-instance-type-list_test.rego
@@ -2,63 +2,63 @@ package spacelift
 
 # Test for denied instances
 test_deny_t2_2xlarge {
-	input := {"terraform": {"resource_changes": [{
+	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.2xlarge"}},
 	}]}}
-	count(deny) == 1 with input as input
-	count(warn) == 0 with input as input
+	count(deny) == 1 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_deny_t2_xlarge {
-	input := {"terraform": {"resource_changes": [{
+	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.xlarge"}},
 	}]}}
-	count(deny) == 1 with input as input
-	count(warn) == 0 with input as input
+	count(deny) == 1 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 # Test for allowed instances (should not warn or deny)
 test_allow_t2_micro {
-	input := {"terraform": {"resource_changes": [{
+	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.micro"}},
 	}]}}
-	count(deny) == 0 with input as input
-	count(warn) == 0 with input as input
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_allow_t2_small {
-	input := {"terraform": {"resource_changes": [{
+	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.small"}},
 	}]}}
-	count(deny) == 0 with input as input
-	count(warn) == 0 with input as input
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_allow_t2_nano {
-	input := {"terraform": {"resource_changes": [{
+	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.nano"}},
 	}]}}
-	count(deny) == 0 with input as input
-	count(warn) == 0 with input as input
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 # Test for instances that should generate a warning
 test_warn_t2_medium {
-	input := {"terraform": {"resource_changes": [{
+	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.medium"}},
 	}]}}
-	count(deny) == 0 with input as input
-	count(warn) == 1 with input as input
+	count(deny) == 0 with input as inp
+	count(warn) == 1 with input as inp
 }

--- a/plan/enforce-password-length.rego
+++ b/plan/enforce-password-length.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # This example plan policy prevents you from creating weak passwords, and warns
 # you when passwords are meh.
 #
@@ -18,10 +20,10 @@ warn[sprintf("We advise that passwords have at least 20 characters (%s)", [resou
 
 new_password[resource] {
 	resource := input.terraform.resource_changes[_]
-	resource.change.actions[_] == "create"
+	"create" in resource.change.actions
 	resource.type == "random_password"
 }
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/enforce-tags-on-resources.rego
+++ b/plan/enforce-tags-on-resources.rego
@@ -18,4 +18,4 @@ deny[sprintf("resource %q does not have all suggested tags (%s)", [resource.addr
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/enforce-terraform-version-list.rego
+++ b/plan/enforce-terraform-version-list.rego
@@ -38,4 +38,4 @@ is_version_notallowed(version) {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/enforce-terraform-version-list_test.rego
+++ b/plan/enforce-terraform-version-list_test.rego
@@ -2,51 +2,51 @@ package spacelift
 
 # Test for denied versions
 test_deny_1_4_1 {
-	input := {"terraform": {"terraform_version": "1.4.1"}}
-	count(deny) == 1 with input as input
-	count(warn) == 0 with input as input
+	inp := {"terraform": {"terraform_version": "1.4.1"}}
+	count(deny) == 1 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_deny_1_4_2 {
-	input := {"terraform": {"terraform_version": "1.4.2"}}
-	count(deny) == 1 with input as input
-	count(warn) == 0 with input as input
+	inp := {"terraform": {"terraform_version": "1.4.2"}}
+	count(deny) == 1 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_deny_1_4_3 {
-	input := {"terraform": {"terraform_version": "1.4.3"}}
-	count(deny) == 1 with input as input
-	count(warn) == 0 with input as input
+	inp := {"terraform": {"terraform_version": "1.4.3"}}
+	count(deny) == 1 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 # Test for allowed versions (should not warn or deny)
 test_allow_1_4_4 {
-	input := {"terraform": {"terraform_version": "1.4.4"}}
-	count(deny) == 0 with input as input
-	count(warn) == 0 with input as input
+	inp := {"terraform": {"terraform_version": "1.4.4"}}
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_allow_1_4_5 {
-	input := {"terraform": {"terraform_version": "1.4.5"}}
-	count(deny) == 0 with input as input
-	count(warn) == 0 with input as input
+	inp := {"terraform": {"terraform_version": "1.4.5"}}
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 test_allow_1_5_0 {
-	input := {"terraform": {"terraform_version": "1.5.0"}}
-	count(deny) == 0 with input as input
-	count(warn) == 0 with input as input
+	inp := {"terraform": {"terraform_version": "1.5.0"}}
+	count(deny) == 0 with input as inp
+	count(warn) == 0 with input as inp
 }
 
 # Test for versions that should generate a warning
 test_warn_1_4_0 {
-	input := {"terraform": {"terraform_version": "1.4.0"}}
-	count(deny) == 0 with input as input
-	count(warn) == 1 with input as input
+	inp := {"terraform": {"terraform_version": "1.4.0"}}
+	count(deny) == 0 with input as inp
+	count(warn) == 1 with input as inp
 }
 
 test_warn_1_5_1 {
-	input := {"terraform": {"terraform_version": "1.5.1"}}
-	count(deny) == 0 with input as input
-	count(warn) == 1 with input as input
+	inp := {"terraform": {"terraform_version": "1.5.1"}}
+	count(deny) == 0 with input as inp
+	count(warn) == 1 with input as inp
 }

--- a/plan/ensure-resource-creation-before-deletion.rego
+++ b/plan/ensure-resource-creation-before-deletion.rego
@@ -19,4 +19,4 @@ deny[sprintf(message, [resource.address])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/infracost-monthly-cost-restriction.rego
+++ b/plan/infracost-monthly-cost-restriction.rego
@@ -29,4 +29,4 @@ warn[sprintf("monthly cost increase greater than %d%% (%.2f%%)", [threshold, per
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/kics-severity-counter.rego
+++ b/plan/kics-severity-counter.rego
@@ -1,7 +1,7 @@
 package spacelift
 
-# This policy will give you a warning with all the info, low and medium issues number 
-# and deny any run that has a high severity issue. 
+# This policy will give you a warning with all the info, low and medium issues number
+# and deny any run that has a high severity issue.
 
 warn[sprintf(message, [info, low, medium])] {
 	message := "You have: %d info issues, %d low issues, %d medium issues"
@@ -19,7 +19,7 @@ deny[sprintf(message, [results, p])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true
 
-# Learn more about how to integrate custom inputs here: 
+# Learn more about how to integrate custom inputs here:
 # https://spacelift.io/blog/integrating-security-tools-with-spacelift

--- a/plan/require-human-review-for-unreachable-ansible-hosts.rego
+++ b/plan/require-human-review-for-unreachable-ansible-hosts.rego
@@ -7,4 +7,4 @@ warn["Some hosts were unreachable"] {
 	input.ansible.dark != {}
 }
 
-sample = true
+sample := true

--- a/plan/require-human-review-for-update-deletion.rego
+++ b/plan/require-human-review-for-update-deletion.rego
@@ -16,4 +16,4 @@ warn[sprintf(message, [action, resource.address])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/require-reasonable-commit-size.rego
+++ b/plan/require-reasonable-commit-size.rego
@@ -27,4 +27,4 @@ too_many_changes[msg] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/terrascan-violated-policies.rego
+++ b/plan/terrascan-violated-policies.rego
@@ -1,6 +1,6 @@
 package spacelift
 
-# This policy checks the number of violated terrascan policies 
+# This policy checks the number of violated terrascan policies
 # and shows a warning with the number of them, also, if the number of violated policies is greater than 2, it will deny the run.
 
 warn[sprintf(message, [results])] {
@@ -17,7 +17,7 @@ deny[sprintf(message, [results, p])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true
 
-# Learn more about how to integrate custom inputs here: 
+# Learn more about how to integrate custom inputs here:
 # https://spacelift.io/blog/integrating-security-tools-with-spacelift

--- a/plan/tfsec-high-severity-issues.rego
+++ b/plan/tfsec-high-severity-issues.rego
@@ -11,7 +11,7 @@ warn[sprintf(message, [p])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true
 
-# Learn more about how to integrate custom inputs here: 
+# Learn more about how to integrate custom inputs here:
 # https://spacelift.io/blog/integrating-security-tools-with-spacelift

--- a/plan/trusted-engineers-bypass-review.rego
+++ b/plan/trusted-engineers-bypass-review.rego
@@ -15,4 +15,4 @@ warn[sprintf(message, [author])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/warn-on-change-sensitive-resources.rego
+++ b/plan/warn-on-change-sensitive-resources.rego
@@ -25,4 +25,4 @@ warn[sprintf(message, [resource.address, action])] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/plan/warn-on-change-sensitive-resources_test.rego
+++ b/plan/warn-on-change-sensitive-resources_test.rego
@@ -2,47 +2,43 @@ package spacelift
 
 # Test for `aws_iam_user` resource being updated
 test_warn_update_iam_user {
-	input := {"terraform": {"resource_changes": [{
+	count(warn) == 1 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_user.example",
 		"type": "aws_iam_user",
 		"change": {"actions": ["update"]},
 	}]}}
-	count(warn) == 1 with input as input
 }
 
 # Test for `aws_iam_role` resource being deleted
 test_warn_delete_iam_role {
-	input := {"terraform": {"resource_changes": [{
+	count(warn) == 1 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_role.example",
 		"type": "aws_iam_role",
 		"change": {"actions": ["delete"]},
 	}]}}
-	count(warn) == 1 with input as input
 }
 
 # Test for non-sensitive resource being updated
 test_no_warn_update_ec2_instance {
-	input := {"terraform": {"resource_changes": [{
+	count(warn) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"actions": ["update"]},
 	}]}}
-	count(warn) == 0 with input as input
 }
 
 # Test for sensitive resource being created (shouldn't trigger a warning)
 test_no_warn_create_iam_policy {
-	input := {"terraform": {"resource_changes": [{
+	count(warn) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_policy.example",
 		"type": "aws_iam_policy",
 		"change": {"actions": ["create"]},
 	}]}}
-	count(warn) == 0 with input as input
 }
 
 # Test for multiple sensitive resources being updated and deleted (should trigger multiple warnings)
 test_multiple_warnings {
-	input := {"terraform": {"resource_changes": [
+	count(warn) == 2 with input as {"terraform": {"resource_changes": [
 		{
 			"address": "aws_iam_policy.example",
 			"type": "aws_iam_policy",
@@ -54,5 +50,4 @@ test_multiple_warnings {
 			"change": {"actions": ["delete"]},
 		},
 	]}}
-	count(warn) == 2 with input as input
 }

--- a/push/allow-forks.rego
+++ b/push/allow-forks.rego
@@ -14,8 +14,8 @@ allow_fork {
 	valid_owners[input.pull_request.head_owner]
 }
 
-propose = true
+propose := true
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/cancel-in-progress-runs.rego
+++ b/push/cancel-in-progress-runs.rego
@@ -1,7 +1,7 @@
 package spacelift
 
-# The push policy can be used to have the new run pre-empt any runs that are 
-# currently in progress. The input document includes the in_progress key, which 
+# The push policy can be used to have the new run pre-empt any runs that are
+# currently in progress. The input document includes the in_progress key, which
 # contains an array of runs that are currently either still queued or are awaiting
 # human confirmation. You can use it in conjunction with the cancel rule like this:
 cancel[run.id] {
@@ -13,4 +13,4 @@ cancel[run.id] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/create-proposed-run-from-env-pr-labels.rego
+++ b/push/create-proposed-run-from-env-pr-labels.rego
@@ -14,4 +14,4 @@ propose {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/deploy-with-git-tag.rego
+++ b/push/deploy-with-git-tag.rego
@@ -3,7 +3,7 @@ package spacelift
 # This policy deploys from a newly created git tag rather than from a branch
 
 track {
-	re_match(`^\d+\.\d+\.\d+$`, input.push.tag)
+	regex.match(`^\d+\.\d+\.\d+$`, input.push.tag)
 }
 
 propose {
@@ -12,4 +12,4 @@ propose {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/deploy-with-pr-label.rego
+++ b/push/deploy-with-pr-label.rego
@@ -15,8 +15,8 @@ track {
 	labeled
 }
 
-propose = true
+propose := true
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/ignore-changes-outside-root.rego
+++ b/push/ignore-changes-outside-root.rego
@@ -37,4 +37,4 @@ affected {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/ignore-changes-outside-root_test.rego
+++ b/push/ignore-changes-outside-root_test.rego
@@ -49,7 +49,7 @@ test_propose_not_affected {
 	not propose with affected as false
 }
 
-matching_branch_input = {
+matching_branch_input := {
 	"push": {"branch": "main"},
 	"stack": {"branch": "main"},
 }

--- a/push/lock-button-pauses-runs-by-pushes.rego
+++ b/push/lock-button-pauses-runs-by-pushes.rego
@@ -1,6 +1,6 @@
 package spacelift
 
-#This is the default push policy with the condition that the locked button cannot be set by anyone.
+# This is the default push policy with the condition that the locked button cannot be set by anyone.
 
 track {
 	affected
@@ -24,4 +24,4 @@ affected {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/lock-button-pauses-runs-by-pushes_test.rego
+++ b/push/lock-button-pauses-runs-by-pushes_test.rego
@@ -1,7 +1,7 @@
 package spacelift
 
 # Input for locked stack
-locked_stack_input = {
+locked_stack_input := {
 	"push": {
 		"affected_files": ["main.tf"],
 		"branch": "main",
@@ -14,7 +14,7 @@ locked_stack_input = {
 }
 
 # Input for unlocked stack (as you provided)
-unlocked_stack_input = {
+unlocked_stack_input := {
 	"push": {
 		"affected_files": ["main.tf"],
 		"branch": "main",
@@ -28,8 +28,8 @@ unlocked_stack_input = {
 
 # Test that propose and track are true for unlocked stack
 test_propose_and_track_for_unlocked_stack {
-	result_propose_unlocked := propose with input as unlocked_stack_input
-	result_track_unlocked := track with input as unlocked_stack_input
+	propose with input as unlocked_stack_input
+	track with input as unlocked_stack_input
 }
 
 # Test that propose and track are false for locked stack

--- a/push/pr-comment-driven-user.rego
+++ b/push/pr-comment-driven-user.rego
@@ -1,5 +1,7 @@
 package spacelift
 
+import future.keywords.in
+
 # This policy requires the following permissions on your VCS provider:
 # - Read access to `issues` repository permissions
 # - Subscribe to `issues:comments` event
@@ -14,11 +16,11 @@ package spacelift
 # Furthermore, Spacelift only processes event data for new comments,
 # and will not receive event data for edited or deleted comments.
 
-development_team = {"user1", "user2"}
+development_team := {"user1", "user2"}
 
 # This rule returns true if the user is in the development team
 is_development_team_member(user) {
-	development_team[_] == user
+	user in development_team
 }
 
 # This rule creates a tracked run from a comment when it is a valid team member
@@ -28,4 +30,4 @@ track {
 	is_development_team_member(input.pull_request.action_initiator)
 }
 
-sample = true
+sample := true

--- a/push/pr-comment-driven-user_test.rego
+++ b/push/pr-comment-driven-user_test.rego
@@ -2,7 +2,7 @@ package spacelift
 
 # Test when everything is valid
 test_track_valid {
-	input := {
+	track with input as {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift deploy testStack",
@@ -10,12 +10,11 @@ test_track_valid {
 		},
 		"stack": {"id": "testStack"},
 	}
-	track with input as input
 }
 
 # Test for an invalid comment
 test_not_track_invalid_comment {
-	input := {
+	not track with input as {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift wrong deploy",
@@ -23,12 +22,11 @@ test_not_track_invalid_comment {
 		},
 		"stack": {"id": "testStack"},
 	}
-	not track with input as input
 }
 
 # Test for a non-team member
 test_not_track_non_team_member {
-	input := {
+	not track with input as {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift deploy testStack",
@@ -36,5 +34,4 @@ test_not_track_non_team_member {
 		},
 		"stack": {"id": "testStack"},
 	}
-	not track with input as input
 }

--- a/push/prs-only.rego
+++ b/push/prs-only.rego
@@ -23,4 +23,4 @@ ignore {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/set-head-commit-no-trigger.rego
+++ b/push/set-head-commit-no-trigger.rego
@@ -12,8 +12,8 @@ propose {
 	not track
 }
 
-notrigger = true
+notrigger := true
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/tag-driven-tf-module-release-flow.rego
+++ b/push/tag-driven-tf-module-release-flow.rego
@@ -4,16 +4,14 @@ package spacelift
 # It then parses the tag event data and uses that value for the module version.
 # Here, we remove a git tag prefixed with "v" as the Terraform Module Registry only supports versions in a numeric "X.X.X" format.
 
-module_version := version {
-	version := trim_prefix(input.push.tag, "v")
-}
+module_version := trim_prefix(input.push.tag, "v")
 
 track {
 	input.push.tag != ""
 }
 
-propose = true
+propose := true
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/terragrunt-monorepo-ignore-changes-outside-root.rego
+++ b/push/terragrunt-monorepo-ignore-changes-outside-root.rego
@@ -59,4 +59,4 @@ affected {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/push/track-using-labels.rego
+++ b/push/track-using-labels.rego
@@ -38,4 +38,4 @@ affected {
 	endswith(path, tracked_extensions[j])
 }
 
-sample = true
+sample := true

--- a/push/track-using-labels_test.rego
+++ b/push/track-using-labels_test.rego
@@ -11,72 +11,64 @@ mock_stack_labels_with_trackings := {"labels": ["trackeddirectories:tracked", "t
 
 # Test: track rule with different branches
 test_track_different_branches {
-	input := {
+	not track with input as {
 		"push": {"branch": "main"},
 		"stack": {"branch": "develop"},
 	}
-	not track with input as input
 }
 
 # Test: propose rule with non-empty branch
 test_propose_non_empty_branch {
-	input := {
+	propose with input as {
 		"push": {"branch": "main"},
 		"stack": {},
 	}
-	propose with input as input
 }
 
 # Test: propose rule with empty branch
 test_propose_empty_branch {
-	input := {
+	not propose with input as {
 		"push": {"branch": ""},
 		"stack": {},
 	}
-	not propose with input as input
 }
 
 # Test: affected by directory path
 test_affected_directory {
-	input := {
+	affected with input as {
 		"push": mock_push_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
-	affected with input as input
 }
 
 # Test: affected by file extension
 test_affected_extension {
-	input := {
+	affected with input as {
 		"push": mock_push_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
-	affected with input as input
 }
 
 # Test: not track by directory path
 test_not_affected_directory {
-	input := {
+	not track with input as {
 		"push": mock_push_not_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
-	not track with input as input
 }
 
 # Test: not track by file extension
 test_not_affected_extension {
-	input := {
+	not track with input as {
 		"push": mock_push_not_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
-	not track with input as input
 }
 
 # Test: track rule with not affected files
 test_ignore_not_affected {
-	input := {
+	not track with input as {
 		"push": mock_push_not_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
-	not track with input as input
 }

--- a/trigger/automated-retries.rego
+++ b/trigger/automated-retries.rego
@@ -1,9 +1,9 @@
 package spacelift
 
-# Sometimes Terraform or Pulumi deployments fail for a reason that has nothing to do 
+# Sometimes Terraform or Pulumi deployments fail for a reason that has nothing to do
 # with the code - think eventual consistency between various cloud subsystems, transient
 # API errors etc. It would be great if you could restart the failed run. Oh, and let's
-# make sure new runs are not created in a crazy loop - since policy-triggered runs 
+# make sure new runs are not created in a crazy loop - since policy-triggered runs
 # trigger another policy evaluation:
 
 trigger[stack.id] {
@@ -17,4 +17,4 @@ trigger[stack.id] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true

--- a/trigger/trigger-dependencies-via-labels.rego
+++ b/trigger/trigger-dependencies-via-labels.rego
@@ -14,4 +14,4 @@ trigger[stack.id] {
 
 # Learn more about sampling policy evaluations here:
 # https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
-sample = true
+sample := true


### PR DESCRIPTION
# Description of the change

Hi there Spacelift friends 👋🙂 This PR introduces [Regal](https://github.com/styrainc/regal) (as I know some of you are familiar with from before!) for linting the Rego found in this repo.

A few issues reported have been fixed as part of the PR:

* [custom-has-key-construct](https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct)
* [custom-in-construct](https://docs.styra.com/regal/rules/idiomatic/custom-in-construct)
* [prefer-set-or-object-rule](https://docs.styra.com/regal/rules/idiomatic/prefer-set-or-object-rule)
* [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)
* [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)
* [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)
* [use-in-operator](https://docs.styra.com/regal/rules/idiomatic/use-in-operator)
* [use-some-for-output-vars](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)

A few rules have been ignored for now using the provided `.regal/config.yaml` file. Some of those would be easy to fix later, but I'll leave that decision to you.

In addition to the Regal rules, I've also made sure the project "builds" using OPA [strict mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode) (`opa check --strict`). The violations related to that have also been fixed fixed:

* Assignment shadowing `input`
* Unused assignment

Finally, I've added a Regal step to the project's CI workflow, so that new code is linted as part of that process. I've also removed the formatter check job, as that is included in Regal (the [opa-fmt](https://docs.styra.com/regal/rules/style/opa-fmt) rule).

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
