### PR TITLE
fix: Simplify enforce instance type policy by using sets

### DIFF
--- a/examples/plan/enforce-instance-type-list.rego
+++ b/examples/plan/enforce-instance-type-list.rego
@@ -7,10 +7,10 @@ import rego.v1
 # the instance type.
 
 # Define the deny list of instance types
-deny_list := ["t2.2xlarge", "t2.xlarge"]
+deny_list := {"t2.2xlarge", "t2.xlarge"}
 
 # Define the allow list of instance types
-allow_list := ["t2.nano", "t2.micro", "t2.small"]
+allow_list := {"t2.nano", "t2.micro", "t2.small"}
 
 # Deny if the instance type is in the deny list
 deny contains sprintf(message, [resource.address, instance]) if {
@@ -18,7 +18,7 @@ deny contains sprintf(message, [resource.address, instance]) if {
 	resource := input.terraform.resource_changes[_]
 	resource.type == "aws_instance"
 	instance := resource.change.after.instance_type
-	is_in_deny_list(instance)
+	deny_list[instance]
 }
 
 # Warn if the instance type is not in the allow or deny lists
@@ -27,18 +27,8 @@ warn contains sprintf(message, [resource.address, instance]) if {
 	resource := input.terraform.resource_changes[_]
 	resource.type == "aws_instance"
 	instance := resource.change.after.instance_type
-	not is_in_allow_list(instance)
-	not is_in_deny_list(instance)
-}
-
-# Helper function to check if instance type is in the allow list
-is_in_allow_list(instance) if {
-	instance in allow_list
-}
-
-# Helper function to check if instance type is in the deny list
-is_in_deny_list(instance) if {
-	instance in deny_list
+	not allow_list[instance]
+	not deny_list[instance]
 }
 
 # Learn more about sampling policy evaluations here:


### PR DESCRIPTION
# Description of the change
Helper functions and iteration seem unnecessary here

<!-- Please describe the changes that are being added by this PR -->

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of a sample Rego policy that changes data structures and membership checks but keeps the same enforcement intent.
> 
> **Overview**
> Refactors `examples/plan/enforce-instance-type-list.rego` to represent `allow_list`/`deny_list` as Rego sets instead of arrays and performs membership tests via direct set indexing.
> 
> Removes the `is_in_allow_list`/`is_in_deny_list` helper rules and updates the `deny`/`warn` conditions to use the new set-based checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2b49bfe0db7e655c1cafdbe9e365be514f074cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->