### PR TITLE
feat: notification policy for stack failure origins

### DIFF
--- a/notification/notification-stack-failure-origins.rego
+++ b/notification/notification-stack-failure-origins.rego
@@ -1,0 +1,80 @@
+# Notify author of PR/commit which potentially introduced failure of a Spacelift Stack
+
+package spacelift
+
+import future.keywords.contains
+import future.keywords.if
+
+run_url := sprintf(
+    "https://%s.app.spacelift.io/stack/%s/run/%s",
+    [input.account.name, input.run_updated.stack.id, input.run_updated.run.id],
+)
+
+# Mapping of GitHub usernames to Slack user IDs since display names can't be tagged
+# https://api.slack.com/reference/surfaces/formatting#mentioning-users
+github_to_slack := {
+    "GITHUB_USERNAME_EXAMPLE1": "SLACK_ID_EXAMPLE1",
+    "GITHUB_USERNAME_EXAMPLE2": "SLACK_ID_EXAMPLE2",
+}
+
+github_author := input.run_updated.run.commit.author
+
+# Function to get Slack ID corresponding to GH username from the map if exists, else, mention @here for Slack notification
+get_slack_user_id(github_username) := slack_id if {
+    slack_id := github_to_slack[github_username]
+} else := "here"
+
+# Ensure this is a tracked run and it failed
+tracked_failed if {
+    input.run_updated.run.type == "TRACKED"
+    input.run_updated.run.state == "FAILED"
+}
+
+# Notify via Slack of the failure, mentioning author of the tracked commit that Spacelift ran on
+# Hyperlinks defined as <http://www.example.com|This message *is* a link> - https://api.slack.com/reference/surfaces/formatting#linking-urls
+slack contains {
+    "channel_id": "YOUR_SLACK_CHANNEL",
+    "message": sprintf(
+        concat("", [
+            "⚠️Spacelift Stack Failure⚠️ - `%s`\n",
+            "Hey <@%s>, your commit/PR introduced changes that potentially caused the failure of the `%s` stack.\n",
+            "Check out the <%s|run details here.>\n",
+            "Tracked Commit: <%s|%s>",
+        ]),
+        [
+            input.run_updated.stack.name,
+            slack_user_id,
+            input.run_updated.stack.name,
+            run_url,
+            input.run_updated.run.commit.url,
+            input.run_updated.run.commit.hash,
+        ],
+    ),
+} if {
+    tracked_failed
+    slack_user_id := get_slack_user_id(github_author)
+}
+
+# Write a comment on the PR that introduced the change where this stack failed
+# Use `deduplication_key` to update existing comment related to stack in place, so multiple failures of the same stack won't comment again
+pull_request contains {
+    "commit": input.run_updated.run.commit.hash,
+    "body": sprintf(
+        concat("", [
+            "## ⚠️Spacelift Stack Failure⚠️\n",
+            "@%s - This pull request was deployed and the following Spacelift stack failed:\n",
+            "* ⛔️ `%s` - [view the run here](%s) ⛔️",
+        ]),
+        [
+            github_author,
+            input.run_updated.stack.id,
+            run_url,
+        ],
+    ),
+    "deduplication_key": deduplication_key,
+} if {
+    tracked_failed
+    deduplication_key := input.run_updated.stack.id
+}
+
+sample := true

--- a/notification/notification-stack-failure-origins.yml
+++ b/notification/notification-stack-failure-origins.yml
@@ -1,0 +1,14 @@
+name: Notification to Author of Stack Failure
+source: notification-stack-failure-origins.rego
+type: notification
+description: |
+  This policy is used to write a comment on the GitHub Pull Request which triggered a Spacelift Stack failure and/or sends a Slack message to the user as well.
+labels:
+  - notification
+  - failure
+  - slack
+  - github
+  - pull-request
+  - PR
+  - comment
+  - run

--- a/notification/notification-stack-failure-origins_test.rego
+++ b/notification/notification-stack-failure-origins_test.rego
@@ -1,0 +1,143 @@
+package spacelift_test
+
+import future.keywords.if
+import future.keywords.in
+import future.keywords.contains
+
+import data.spacelift
+
+# Test successful Slack notification for a tracked, failed run
+test_slack_notification_for_tracked_failed_run if {
+    result := spacelift.slack with input as {
+        "account": {"name": "test-account"},
+        "run_updated": {
+            "stack": {"id": "test-stack", "name": "Test Stack"},
+            "run": {
+                "id": "test-run",
+                "type": "TRACKED",
+                "state": "FAILED",
+                "commit": {
+                    "author": "GITHUB_USERNAME_EXAMPLE1",
+                    "hash": "abcdef123456",
+                    "url": "https://github.com/org/repo/commit/abcdef123456"
+                }
+            }
+        }
+    }
+
+    count(result) == 1
+    slack_message := result[_]
+    slack_message.channel_id == "YOUR_SLACK_CHANNEL"
+    contains(slack_message.message, "⚠️Spacelift Stack Failure⚠️ - `Test Stack`")
+    contains(slack_message.message, "Hey <@SLACK_ID_EXAMPLE1>")
+    contains(slack_message.message, "https://test-account.app.spacelift.io/stack/test-stack/run/test-run")
+}
+
+# Test no Slack notification for a non-tracked run
+test_no_slack_notification_for_non_tracked_run if {
+    result := spacelift.slack with input as {
+        "run_updated": {
+            "run": {
+                "type": "PROPOSED",
+                "state": "FAILED"
+            }
+        }
+    }
+
+    count(result) == 0
+}
+
+# Test no Slack notification for a successful FINISHED run
+test_no_slack_notification_for_successful_run if {
+    result := spacelift.slack with input as {
+        "run_updated": {
+            "run": {
+                "type": "TRACKED",
+                "state": "FINISHED"
+            }
+        }
+    }
+
+    count(result) == 0
+}
+
+# Test Slack notification with unknown GitHub user which should route to @here
+test_slack_notification_with_unknown_github_user if {
+    result := spacelift.slack with input as {
+        "account": {"name": "test-account"},
+        "run_updated": {
+            "stack": {"id": "test-stack", "name": "Test Stack"},
+            "run": {
+                "id": "test-run",
+                "type": "TRACKED",
+                "state": "FAILED",
+                "commit": {
+                    "author": "unknown-user",
+                    "hash": "abcdef123456",
+                    "url": "https://github.com/org/repo/commit/abcdef123456"
+                }
+            }
+        }
+    }
+
+    count(result) == 1
+    slack_message := result[_]
+    contains(slack_message.message, "Hey <@here>")
+}
+
+# Test PR comment for a tracked, failed run
+test_pr_comment_for_tracked_failed_run if {
+    result := spacelift.pull_request with input as {
+        "account": {"name": "test-account"},
+        "run_updated": {
+            "stack": {"id": "test-stack", "name": "Test Stack"},
+            "run": {
+                "id": "test-run",
+                "type": "TRACKED",
+                "state": "FAILED",
+                "commit": {
+                    "author": "GITHUB_USERNAME_EXAMPLE1",
+                    "hash": "abcdef123456",
+                    "url": "https://github.com/org/repo/commit/abcdef123456"
+                }
+            }
+        }
+    }
+
+    count(result) == 1
+    pr_comment := result[_]
+    pr_comment.commit == "abcdef123456"
+    contains(pr_comment.body, "## ⚠️Spacelift Stack Failure⚠️")
+    contains(pr_comment.body, "@GITHUB_USERNAME_EXAMPLE1")
+    contains(pr_comment.body, "⛔️ `test-stack`")
+    contains(pr_comment.body, "https://test-account.app.spacelift.io/stack/test-stack/run/test-run")
+    pr_comment.deduplication_key == "test-stack"
+}
+
+# Test no PR comment for a non-tracked run
+test_no_pr_comment_for_non_tracked_run if {
+    result := spacelift.pull_request with input as {
+        "run_updated": {
+            "run": {
+                "type": "PROPOSED",
+                "state": "FAILED"
+            }
+        }
+    }
+
+    count(result) == 0
+}
+
+# Test no PR comment for a successful run
+test_no_pr_comment_for_successful_run if {
+    result := spacelift.pull_request with input as {
+        "run_updated": {
+            "run": {
+                "type": "TRACKED",
+                "state": "FINISHED"
+            }
+        }
+    }
+
+    count(result) == 0
+}


### PR DESCRIPTION
# Description of the change

- Adds a new notification policy to track + notify the origins of a Spacelift Stack failure, aka the author. If someone's PR merge introduced the failure of a stack, it will write a comment on that PR and notify them on Slack.
- This is useful when you have a couple of people working on a project with a lot of stacks, so there's lots of activity and there's fails here and there. This makes it easier to trace and keep all stacks green.
- Add corresponding tests. 
- This is what it looks like:
- ![image](https://github.com/user-attachments/assets/ddae41b3-8c9e-4d24-a32e-9eb23749172e)
- ![image](https://github.com/user-attachments/assets/6c7b6117-544a-4d4f-8723-37f382ed3a27)


## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
