### PR TITLE
feat: add advanced retry policy

### DIFF
--- a/trigger/advanced-automated-retries.rego
+++ b/trigger/advanced-automated-retries.rego
@@ -1,0 +1,48 @@
+package spacelift
+
+# set the maximum number of retries
+default max_retries := 3
+
+# label to use for stack specific retries
+default retry_count_key := "spacelift_retry"
+
+# FN: gets the value of an array of retry labels
+obtain_retries_count(arr) := {x |
+	new_arr := array.concat(arr, [sprintf("%s:0", [retry_count_key])])
+	some i
+	parts := split(new_arr[i], ":")
+	parts[0] == retry_count_key
+	x := to_number(parts[1])
+}
+
+# Get the value of the highest retry stack label
+retry_label := max(obtain_retries_count(input.stack.labels))
+
+# Set the flag for the next iteration
+new_retries := max(obtain_retries_count(input.run.flags)) + 1
+
+retry_flag := sprintf("%s:%d", [retry_count_key, new_retries])
+
+flag[retry_flag]
+
+is_failed_and_tracked {
+	input.run.state == "FAILED"
+	input.run.type == "TRACKED"
+}
+
+# trigger the stack if the max retry label is 0
+trigger[stack.id] {
+	stack := input.stack
+	is_failed_and_tracked
+	retry_label <= 0
+	new_retries <= max_retries
+}
+
+# trigger the stack if the max retry label is defined but only up to the maximum retries
+trigger[stack.id] {
+	stack := input.stack
+	is_failed_and_tracked
+	retry_label > 0
+	new_retries <= retry_label
+	new_retries <= max_retries
+}

--- a/trigger/advanced-automated-retries.yml
+++ b/trigger/advanced-automated-retries.yml
@@ -1,0 +1,13 @@
+name: Advanced Automated Retries
+source: advanced-automated-retries.rego
+type: trigger
+description: |
+  Sometimes Terraform or Pulumi deployments fail for a reason that has nothing to do with the code
+  - think eventual consistency between various cloud subsystems, transient API errors etc.
+  This trigger policy will restart the failed run up to a maximum number of times. This policy can also be configured
+  on a per stack basis by setting `spacelift_retry:<number>` on the stacks labels.
+labels:
+  - trigger
+  - retries
+  - automated
+  - failed

--- a/trigger/advanced-automated-retries.yml
+++ b/trigger/advanced-automated-retries.yml
@@ -2,9 +2,9 @@ name: Advanced Automated Retries
 source: advanced-automated-retries.rego
 type: trigger
 description: |
-  Sometimes Terraform or Pulumi deployments fail for a reason that has nothing to do with the code
+  Sometimes deployments fail for a reason that has nothing to do with the code
   - think eventual consistency between various cloud subsystems, transient API errors etc.
-  This trigger policy will restart the failed run up to a maximum number of times. This policy can also be configured
+  This trigger policy will restart the failed run up to a maximum number of times (default: 3). This policy can also be configured
   on a per stack basis by setting `spacelift_retry:<number>` on the stacks labels.
 labels:
   - trigger

--- a/trigger/advanced-automated-retries_test.rego
+++ b/trigger/advanced-automated-retries_test.rego
@@ -1,0 +1,100 @@
+package spacelift_test
+
+import data.spacelift
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# Test Case 1: Failed and Tracked Run without flags
+test_failed_and_tracked_run_without_flags if {
+	result := spacelift.trigger with input as {
+		"run": {
+			"state": "FAILED",
+			"type": "TRACKED",
+			"flags": [],
+		},
+		"stack": {
+			"id": "stack-one",
+			"labels": [],
+		},
+	}
+	result["stack-one"]
+}
+
+# Test Case 2: Failed and Tracked Run with flags
+test_failed_and_tracked_run_with_flags if {
+	result := spacelift.trigger with input as {
+		"run": {
+			"state": "FAILED",
+			"type": "TRACKED",
+			"flags": ["spacelift_retry:1"],
+		},
+		"stack": {
+			"id": "stack-one",
+			"labels": [],
+		},
+	}
+	result["stack-one"]
+}
+
+# Test Case 3: Failed and Tracked Run with flags at max
+test_failed_and_tracked_run_with_flags_at_max if {
+	count(spacelift.trigger) == 0 with input as {
+		"run": {
+			"state": "FAILED",
+			"type": "TRACKED",
+			"flags": ["spacelift_retry:3"],
+		},
+		"stack": {
+			"id": "stack-one",
+			"labels": [],
+		},
+	}
+}
+
+# Test Case 4: LABELS: Failed and Tracked Run without flags
+test_failed_and_tracked_run_labels_without_flags if {
+	result := spacelift.trigger with input as {
+		"run": {
+			"state": "FAILED",
+			"type": "TRACKED",
+			"flags": [],
+		},
+		"stack": {
+			"id": "stack-one",
+			"labels": ["spacelift_retry:2"],
+		},
+	}
+	result["stack-one"]
+}
+
+# Test Case 5: LABELS: Failed and Tracked Run with flags
+test_failed_and_tracked_run_labels_with_flags if {
+	result := spacelift.trigger with input as {
+		"run": {
+			"state": "FAILED",
+			"type": "TRACKED",
+			"flags": ["spacelift_retry:1"],
+		},
+		"stack": {
+			"id": "stack-one",
+			"labels": ["spacelift_retry:2"],
+		},
+	}
+	result["stack-one"]
+}
+
+# Test Case 6: LABELS: Failed and Tracked Run with flags at max
+test_failed_and_tracked_run_labels_with_flags_at_max if {
+	count(spacelift.trigger) == 0 with input as {
+		"run": {
+			"state": "FAILED",
+			"type": "TRACKED",
+			"flags": ["spacelift_retry:2"],
+		},
+		"stack": {
+			"id": "stack-one",
+			"labels": ["spacelift_retry:2"],
+		},
+	}
+}


### PR DESCRIPTION
# Description of the change

This adds an "advanced retry policy" that will allow users to configure a retry policy that retries more than once.

Users can set the `max_retries` default to the absolute maximum the policy will allow. By default, the policy will retry up to `max_retries` but users can also set the `spacelift_retry:<number>` label on a stack and it will then retry up to that number or up to the policies `max_retries` whichever is less.

If the run succeeds, it does not retry:
![success](https://github.com/user-attachments/assets/8c5773b7-59e4-4c3b-8708-c4e1c6dbcb8d)

If the tracked run fails, it retries 3 times by default:
![defaults](https://github.com/user-attachments/assets/cb6fb4d9-e110-476e-98e4-d3d016c54fa0)

If the stack has the `spacelift_retry:2` label on it, it will only retry twice:
![labels](https://github.com/user-attachments/assets/e2ad45f5-0b0d-41bd-a567-c0bac2d86acd)


## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇