### PR TITLE
ci: update CI workflows and test script

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Regal
-        uses: StyraInc/setup-regal@v0.2.0
+        uses: StyraInc/setup-regal@v1
         with:
           version: v0.11.0
       - run: regal lint --format=github .
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install OPA
         uses: open-policy-agent/setup-opa@v2
@@ -35,10 +35,7 @@ jobs:
       - name: Check syntax
         run: |
           # KLUDGE: plan/check-sanitized-value.rego needs to be ignored because it uses the custom sanitized() function
-          policies=$(find . -type f -regex '.*\.rego$' | grep -v _test.rego | grep -v plan/check-sanitized-value.rego)
-          for policy in $policies; do
-              opa check --strict $policy
-          done
+          find . -name \*.rego ! -regex '.*_test\.rego$' ! -path './plan/check-sanitized-value.rego' -print0 | xargs -0 -n1 opa check --strict
 
   unit-tests:
     name: Unit Tests
@@ -46,7 +43,7 @@ jobs:
 
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install OPA
         uses: open-policy-agent/setup-opa@v2
@@ -55,7 +52,7 @@ jobs:
 
       - name: Run unit tests
         run: |
-          tests=$(find . -type f -regex '.*_test\.rego$')
+          tests=$(find . -type f -name '*_test\.rego')
           for test in $tests; do
               opa test -v $test ${test/_test.rego/.rego}
           done

--- a/run_policy_tests.sh
+++ b/run_policy_tests.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 
-tests=$(find . -type f -regex '.*_test\.rego$')
+STATUS=0
+
+tests=$(find . -type f -name '*_test\.rego')
 for test in $tests; do
-    opa test -v $test ${test/_test.rego/.rego}
+    opa test -v "$test" "${test/_test\.rego/.rego}"
+    ((STATUS=$STATUS + $?))
     echo
 done
+
+# Instead of exiting on first failure as we would with "-e" set, exit at the
+# end with sum of exit codes.
+if [ $STATUS -gt 0 ]; then
+  echo "Failures detected: exiting with status $STATUS" >&2
+fi
+
+exit $STATUS


### PR DESCRIPTION
# Description of the change
- Simplify find calls and remove extra greps
- Update `run_policy_tests.sh` to exit non-0 and print an error on failures (for local use)
- Update `actions/checkout` to `v4`
- Update setup-regal workflow to v1 (note: keeping lint version at `v0.11.0`, since the latest version seems to have a number of issues with the current config

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [ ] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
