### PR TITLE
fix: duplicated template name

### DIFF
--- a/examples/trigger/trigger-dependencies-via-labels.yml
+++ b/examples/trigger/trigger-dependencies-via-labels.yml
@@ -1,4 +1,4 @@
-name: Trigger Dependencies Via Labels With State
+name: Trigger Dependencies Via Labels
 source: trigger-dependencies-via-labels.rego
 type: trigger
 description: |

--- a/templates_test.go
+++ b/templates_test.go
@@ -16,7 +16,19 @@ func TestTemplates(t *testing.T) {
 	require.NotPanics(t, func() {
 		templates := policylib.Templates()
 		require.Greater(t, len(templates), 1, "should have templates")
+		assertUniqueNames(t, templates, "template names must be unique")
 	}, "embedded templates should not panic")
+}
+
+func assertUniqueNames(t *testing.T, templates []policylib.Template, msg string) int {
+	set := map[string]bool{}
+	for _, template := range templates {
+		if set[template.Name] {
+			assert.Failf(t, "duplicate template name: "+template.Name, msg)
+		}
+		set[template.Name] = true
+	}
+	return len(set)
 }
 
 func TestTemplates_Parsing(t *testing.T) {


### PR DESCRIPTION
# Description of the change

We had a duplicated template name. Template names are supposed to be unique.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
