### PR TITLE
Migrate policy templates to Rego v1 syntax

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Regal
         uses: StyraInc/setup-regal@v1
         with:
-          version: v0.11.0
+          version: v0.36.1
       - run: regal lint --format=github .
 
   syntax-check:

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -2,6 +2,18 @@ rules:
   idiomatic:
     no-defined-entrypoint:
       level: ignore
+    # Package names are standardized as "spacelift" across all policy files
+    # regardless of directory structure, as required by Spacelift platform
+    directory-package-mismatch:
+      level: ignore
+    # Single-item collection checks can reduce readability when the collection
+    # might grow in the future or for consistency with multi-item checks
+    single-item-in:
+      level: ignore
+    # Boolean constant assignments (e.g., proposed := input.run.type == "PROPOSED")
+    # are clearer than using if for simple boolean expressions
+    boolean-assignment:
+      level: ignore
   style:
     external-reference:
       level: ignore
@@ -28,3 +40,7 @@ capabilities:
 
 project:
   rego-version: 0
+
+ignore:
+  files:
+  - "testdata/*"

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -25,3 +25,6 @@ capabilities:
     # Feel free to submit a PR to have "spacelift" added as an engine!
     engine: opa
     version: v0.64.0
+
+project:
+  rego-version: 0

--- a/examples/access/downgrade-access-after-hours.rego
+++ b/examples/access/downgrade-access-after-hours.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # When things go wrong it's usually because someone did something, like an infra deployment.
 # Let's try to make sure they're in the office when doing so and restrict write access to business hours
@@ -18,22 +19,22 @@ weekday := time.weekday(now)
 
 ip := input.request.remote_ip
 
-write {
+write if {
 	"Product team" in input.session.teams
 }
 
-deny_write {
+deny_write if {
 	weekend[weekday]
 }
 
-deny_write {
+deny_write if {
 	clock[0] < 9
 }
 
-deny_write {
+deny_write if {
 	clock[0] > 17
 }
 
-deny_write {
+deny_write if {
 	not net.cidr_contains("12.34.56.0/24", ip)
 }

--- a/examples/access/engineering-team-access.rego
+++ b/examples/access/engineering-team-access.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This example access policy gives everyone in the "Engineering" GitHub team
 # read access to the stack.
@@ -8,7 +9,7 @@ import future.keywords.in
 # You can read more about access policies here:
 # https://docs.spacelift.io/concepts/policy/stack-access-policy
 
-read {
+read if {
 	"Engineering" in input.session.teams
 }
 

--- a/examples/access/label-based-team-access.rego
+++ b/examples/access/label-based-team-access.rego
@@ -1,7 +1,7 @@
 package spacelift
 
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy allow you to tag a repo with a "access:<level>:<team>" label to
 #  grant access to Stacks via labels.
@@ -17,10 +17,10 @@ trim_whitespace(s) := concat("-", parts) if {
 }
 
 # Convert all Teams to the ID format
-teams[trim_whitespace(input.session.teams[_])]
+teams contains trim_whitespace(input.session.teams[_])
 
 # Find access pattern matching labels and return just "access:team" for each
-labels[trim_prefix(label, "access:")] {
+labels contains trim_prefix(label, "access:") if {
 	some label in input.stack.labels
 	not label == ""
 	regex.match(`^access:(read|write|deny):[^:]+$`, label)

--- a/examples/access/label-based-team-access_test.rego
+++ b/examples/access/label-based-team-access_test.rego
@@ -1,17 +1,20 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # in most cases read/write/deny act exactly the same, so tests
 #   will only focus on specifics for those when it applies
 
-test_no_denywrite_if_nothing {
-	not deny_write with input as {
+test_no_denywrite_if_nothing if {
+	not spacelift.deny_write with input as {
 		"session": {"teams": []},
 		"stack": {"labels": []},
 	}
 }
 
-test_denywrite_if_administrative {
-	deny_write with input as {
+test_denywrite_if_administrative if {
+	spacelift.deny_write with input as {
 		"session": {"teams": []},
 		"stack": {
 			"administrative": true,
@@ -20,71 +23,71 @@ test_denywrite_if_administrative {
 	}
 }
 
-test_no_write_if_nothing {
-	not write with input as {
+test_no_write_if_nothing if {
+	not spacelift.write with input as {
 		"session": {"teams": []},
 		"stack": {"labels": []},
 	}
 }
 
-test_no_write_if_label {
-	not write with input as {
+test_no_write_if_label if {
+	not spacelift.write with input as {
 		"session": {"teams": []},
 		"stack": {"labels": ["access:write:my-team"]},
 	}
 }
 
-test_no_write_if_wrong_team {
-	not write with input as {
+test_no_write_if_wrong_team if {
+	not spacelift.write with input as {
 		"session": {"teams": ["My_Team"]},
 		"stack": {"labels": ["access:write:my-team"]},
 	}
 }
 
-test_write_if_correct_team {
-	write with input as {
+test_write_if_correct_team if {
+	spacelift.write with input as {
 		"session": {"teams": ["My Team"]},
 		"stack": {"labels": ["access:write:my-team"]},
 	}
 }
 
-test_write_if_correct_team2 {
-	write with input as {
+test_write_if_correct_team2 if {
+	spacelift.write with input as {
 		"session": {"teams": ["My - Team"]},
 		"stack": {"labels": ["access:write:my-team"]},
 	}
 }
 
-test_no_write_if_wrong_level {
-	not write with input as {
+test_no_write_if_wrong_level if {
+	not spacelift.write with input as {
 		"session": {"teams": ["My - Team"]},
 		"stack": {"labels": ["access:read:my-team"]},
 	}
 }
 
-test_no_write_if_wrong_wrong_label {
-	not write with input as {
+test_no_write_if_wrong_wrong_label if {
+	not spacelift.write with input as {
 		"session": {"teams": ["My - Team"]},
 		"stack": {"labels": ["access:write:*"]},
 	}
 }
 
-test_no_write_if_wrong_wrong_label2 {
-	not write with input as {
+test_no_write_if_wrong_wrong_label2 if {
+	not spacelift.write with input as {
 		"session": {"teams": ["My - Team"]},
 		"stack": {"labels": ["write"]},
 	}
 }
 
-test_no_write_if_wrong_wrong_label3 {
-	not write with input as {
+test_no_write_if_wrong_wrong_label3 if {
+	not spacelift.write with input as {
 		"session": {"teams": ["My - Team"]},
 		"stack": {"labels": ["write:my-team"]},
 	}
 }
 
-test_no_write_if_wrong_wrong_label4 {
-	not write with input as {
+test_no_write_if_wrong_wrong_label4 if {
+	not spacelift.write with input as {
 		"session": {"teams": ["My - Team"]},
 		"stack": {"labels": ["access:write:my-team:haha"]},
 	}

--- a/examples/access/protect-administrative-stacks.rego
+++ b/examples/access/protect-administrative-stacks.rego
@@ -1,11 +1,14 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Administrative stacks are powerful - getting write access to one is almost
 # as good as being an admin - you can define and attach contexts and policies.
 # So let's deny write access to them entirely. This works since access policies
 # are not evaluated for admin users.
 
-deny_write {
+deny_write if {
 	input.stack.administrative
 }
 

--- a/examples/access/slack-channel-access.rego
+++ b/examples/access/slack-channel-access.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Assuming you have the Slack integration setup, you could
 # attach this policy to a given stack, and this would provide
 # the Slack Channel "dev-notifications" access to your Spacelift
@@ -7,7 +10,7 @@ package spacelift
 #
 # NOTE: If you are looking to scope access to individual Slack channels
 # you should consider using the channel id, rather than the name, as names can change.
-write {
+write if {
 	input.slack.channel.name = "dev-notifications"
 }
 

--- a/examples/access/who-when-where-access-restrictions.rego
+++ b/examples/access/who-when-where-access-restrictions.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # In case things go wrong, we want you to be there.
 #
@@ -24,26 +25,26 @@ ip := input.request.remote_ip
 # for who can have write access, when, and from where (the ip)
 #
 # Allow write access from the Product team
-write {
+write if {
 	"Product team" in input.session.teams
 }
 
 # Only allow access during weekdays
-deny_write {
+deny_write if {
 	weekend[weekday]
 }
 
 # Only allow access during 9-5 time zone
-deny_write {
+deny_write if {
 	clock[0] < 9
 }
 
-deny_write {
+deny_write if {
 	clock[0] > 17
 }
 
 # Only allow access from the 12.34.56.0/24 CIDR
-deny_write {
+deny_write if {
 	not net.cidr_contains("12.34.56.0/24", ip)
 }
 

--- a/examples/approval/allowlist-task-commands.rego
+++ b/examples/approval/allowlist-task-commands.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # Define what commands are allowed
 allowlist := ["ls", "ps"]

--- a/examples/approval/allowlist-task-commands_test.rego
+++ b/examples/approval/allowlist-task-commands_test.rego
@@ -1,10 +1,9 @@
 package spacelift_test
 
+import rego.v1
+
 # Import the testing library
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test - Approve if not a task
 test_not_a_task_approves if {
@@ -27,7 +26,7 @@ test_two_or_more_approvals if {
 	spacelift.approve with input as {"reviews": {"current": {"approvals": [{"author": "user1"}, {"author": "user2"}]}}}
 }
 
-# Test - Do not approve with less than two approvals
+# Test - Do not spacelift.approve with less than two approvals
 test_less_than_two_approvals_does_not_approve if {
 	not spacelift.approve with input as {"reviews": {"current": {"approvals": [{"author": "user1"}]}}}
 }

--- a/examples/approval/approval-outside-working-hours.rego
+++ b/examples/approval/approval-outside-working-hours.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Extract the UTC hour from the provided timestamp and declare our variables.
 utc_hour := time.clock(input.run.created_at)[0]
 
@@ -8,30 +11,30 @@ weekend := {"Saturday", "Sunday"}
 weekday := time.weekday(utc_hour)
 
 # If it's before 9am or after 5pm or earlier UTC, automatically approve
-approve {
+approve if {
 	utc_hour >= 9
 	utc_hour <= 17
 	weekday
 }
 
 # If it's before 9am or after 5pm UTC, require at least one approval and no rejections.
-approve {
+approve if {
 	utc_hour > 17
 	count(input.reviews.current.approvals) >= 1
 }
 
-approve {
+approve if {
 	utc_hour < 9
 	count(input.reviews.current.approvals) >= 1
 }
 
 # require approval access during weekdays
-approve {
+approve if {
 	weekend[weekday]
 	count(input.reviews.current.approvals) >= 1
 }
 
-reject {
+reject if {
 	count(input.reviews.current.rejections) > 0
 }
 

--- a/examples/approval/approval-outside-working-hours_test.rego
+++ b/examples/approval/approval-outside-working-hours_test.rego
@@ -1,4 +1,7 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Mock data
 mock_created_at_weekday_morning := 1692790710000000000
@@ -8,56 +11,56 @@ mock_created_at_weekday_evening := 1692823110000000000
 mock_created_at_weekend := 1692477510000000000
 
 # Test automatic approval for a weekday between 9am to 5pm
-test_automatic_approve_weekday_morning {
-	approve with input as {
+test_automatic_approve_weekday_morning if {
+	spacelift.approve with input as {
 		"run": {"created_at": mock_created_at_weekday_morning},
 		"reviews": {"current": {"approvals": [], "rejections": []}},
 	}
 }
 
 # Test required approval for a weekday after 5pm
-test_required_approval_weekday_evening {
-	approve with input as {
+test_required_approval_weekday_evening if {
+	spacelift.approve with input as {
 		"run": {"created_at": mock_created_at_weekday_evening},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": []}},
 	}
 }
 
 # Test missing approval for a weekday after 5pm
-test_missing_approval_weekday_evening {
-	not approve with input as {
+test_missing_approval_weekday_evening if {
+	not spacelift.approve with input as {
 		"run": {"created_at": mock_created_at_weekday_evening},
 		"reviews": {"current": {"approvals": [], "rejections": []}},
 	}
 }
 
 # Test required approval during weekend
-test_required_approval_weekend {
-	approve with input as {
+test_required_approval_weekend if {
+	spacelift.approve with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": []}},
 	}
 }
 
 # Test missing approval during weekend
-test_missing_approval_weekend {
-	not approve with input as {
+test_missing_approval_weekend if {
+	not spacelift.approve with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": [], "rejections": []}},
 	}
 }
 
 # Test reject due to a rejection review
-test_rejection_due_to_review {
-	reject with input as {
+test_rejection_due_to_review if {
+	spacelift.reject with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": ["user2"]}},
 	}
 }
 
 # Test no rejection when there's no rejection review
-test_no_rejection_when_no_review {
-	not reject with input as {
+test_no_rejection_when_no_review if {
+	not spacelift.reject with input as {
 		"run": {"created_at": mock_created_at_weekend},
 		"reviews": {"current": {"approvals": ["user1"], "rejections": []}},
 	}

--- a/examples/approval/require-approval-from-security-team.rego
+++ b/examples/approval/require-approval-from-security-team.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy approves any runs when someone from Security team approves the changes to the resources in the list,
 # and rejects any runs when someone from other teams tries to approve the changes.
@@ -8,7 +9,7 @@ import future.keywords.in
 # This policy can be combined with automatic policy attachment (https://docs.spacelift.io/concepts/policy#automatically)
 # to automatically enforce it across stacks.
 
-approve {
+approve if {
 	input.run.state != "UNCONFIRMED"
 }
 
@@ -22,7 +23,7 @@ approval_list := [
 	"aws_iam_user_policy",
 ]
 
-requires_approval {
+requires_approval if {
 	# Loop over each resource change in the plan
 	resource := input.run.changes[_]
 
@@ -32,7 +33,7 @@ requires_approval {
 	resource.entity.type == approval_list[_]
 }
 
-requires_approval {
+requires_approval if {
 	# Loop over each resource change in the plan
 	resource := input.run.changes[_]
 
@@ -42,7 +43,7 @@ requires_approval {
 	resource.entity.type == approval_list[_]
 }
 
-requires_approval {
+requires_approval if {
 	# Loop over each resource change in the plan
 	resource := input.run.changes[_]
 
@@ -55,18 +56,18 @@ requires_approval {
 approvals := input.reviews.current.approvals
 
 # Let's define what it means to be approved by Security team.
-security_approval {
+security_approval if {
 	"Security" in approvals[_].session.teams
 }
 
 # Approve when Security team approve and Require at least 1 approval:
-approve {
+approve if {
 	security_approval
 	count(input.reviews.current.approvals) > 0
 }
 
 # Require at least 1 rejection
-reject {
+reject if {
 	count(input.reviews.current.rejections) > 0
 }
 

--- a/examples/approval/require-approval-from-security-team.rego
+++ b/examples/approval/require-approval-from-security-team.rego
@@ -9,10 +9,6 @@ import rego.v1
 # This policy can be combined with automatic policy attachment (https://docs.spacelift.io/concepts/policy#automatically)
 # to automatically enforce it across stacks.
 
-approve if {
-	input.run.state != "UNCONFIRMED"
-}
-
 approval_list := [
 	"aws_iam_access_key",
 	"aws_security_group",
@@ -30,7 +26,7 @@ requires_approval if {
 	# Check if any of the actions on the resource is "added"
 	action := resource.actions[_]
 	action == "added"
-	resource.entity.type == approval_list[_]
+	resource.entity.type in approval_list
 }
 
 requires_approval if {
@@ -40,7 +36,7 @@ requires_approval if {
 	# Check if any of the actions on the resource is "changed"
 	action := resource.actions[_]
 	action == "changed"
-	resource.entity.type == approval_list[_]
+	resource.entity.type in approval_list
 }
 
 requires_approval if {
@@ -50,7 +46,7 @@ requires_approval if {
 	# Check if any of the actions on the resource is "deleted"
 	action := resource.actions[_]
 	action == "deleted"
-	resource.entity.type == approval_list[_]
+	resource.entity.type in approval_list
 }
 
 approvals := input.reviews.current.approvals
@@ -58,6 +54,10 @@ approvals := input.reviews.current.approvals
 # Let's define what it means to be approved by Security team.
 security_approval if {
 	"Security" in approvals[_].session.teams
+}
+
+approve if {
+	input.run.state != "UNCONFIRMED"
 }
 
 # Approve when Security team approve and Require at least 1 approval:

--- a/examples/approval/require-approval-from-security-team_test.rego
+++ b/examples/approval/require-approval-from-security-team_test.rego
@@ -1,24 +1,27 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test that the policy requires approval for changes to specified resources
-test_requires_approval_resource_changes {
-	requires_approval with input as {"run": {"changes": [{
+test_requires_approval_resource_changes if {
+	spacelift.requires_approval with input as {"run": {"changes": [{
 		"actions": ["added"],
 		"entity": {"type": "aws_iam_access_key"},
 	}]}}
 }
 
 # Test approval for security team
-test_approve_security_team {
-	approve with input as {"reviews": {"current": {"approvals": [{"session": {"teams": ["Security"]}}]}}}
+test_approve_security_team if {
+	spacelift.approve with input as {"reviews": {"current": {"approvals": [{"session": {"teams": ["Security"]}}]}}}
 }
 
 # Test rejection for non-security team
-test_reject_non_security_team {
-	not approve with input as {"reviews": {"current": {"approvals": [{"session": {"teams": ["Development"]}}]}}}
+test_reject_non_security_team if {
+	not spacelift.approve with input as {"reviews": {"current": {"approvals": [{"session": {"teams": ["Development"]}}]}}}
 }
 
 # Test that reject works when someone from a non-security team tries to approve
-test_reject_works {
-	reject with input as {"reviews": {"current": {"rejections": [1]}}}
+test_reject_works if {
+	spacelift.reject with input as {"reviews": {"current": {"rejections": [1]}}}
 }

--- a/examples/approval/require-private-worker.rego
+++ b/examples/approval/require-private-worker.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy approves any runs where the stack uses a private worker, and rejects any runs
 # where the stack uses a public worker. The policy needs to define an "approve" rule as well
 # as a "reject" rule to avoid the policy evaluation going into an "UNDECIDED" state for runs on private workers.
@@ -8,12 +11,12 @@ package spacelift
 # to automatically enforce it across stacks.
 
 # Approve any runs on private workers
-approve {
+approve if {
 	not input.stack.worker_pool.public
 }
 
 # Reject any runs on public workers
-reject {
+reject if {
 	input.stack.worker_pool.public
 }
 

--- a/examples/approval/require-private-worker_test.rego
+++ b/examples/approval/require-private-worker_test.rego
@@ -1,17 +1,20 @@
-package spacelift
+package spacelift_test
 
-test_reject_public_worker {
-	reject with input as {"stack": {"worker_pool": {"public": true}}}
+import data.spacelift
+import rego.v1
+
+test_reject_public_worker if {
+	spacelift.reject with input as {"stack": {"worker_pool": {"public": true}}}
 }
 
-test_reject_private_worker {
-	not reject with input as {"stack": {"worker_pool": {"public": false}}}
+test_reject_private_worker if {
+	not spacelift.reject with input as {"stack": {"worker_pool": {"public": false}}}
 }
 
-test_approve_public_worker {
-	not approve with input as {"stack": {"worker_pool": {"public": true}}}
+test_approve_public_worker if {
+	not spacelift.approve with input as {"stack": {"worker_pool": {"public": true}}}
 }
 
-test_approve_private_worker {
-	approve with input as {"stack": {"worker_pool": {"public": false}}}
+test_approve_private_worker if {
+	spacelift.approve with input as {"stack": {"worker_pool": {"public": false}}}
 }

--- a/examples/approval/role-based-approval.rego
+++ b/examples/approval/role-based-approval.rego
@@ -1,43 +1,44 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # First, let's define all conditions that require explicit
 # user approval.
-requires_approval {
+requires_approval if {
 	input.run.state == "UNCONFIRMED"
 }
 
-requires_approval {
+requires_approval if {
 	input.run.type == "TASK"
 }
 
-approve {
+approve if {
 	not requires_approval
 }
 
 approvals := input.reviews.current.approvals
 
 # Let's define what it means to be approved by a director, DevOps and Security.
-director_approval {
+director_approval if {
 	"Director" in approvals[_].session.teams
 }
 
-devops_approval {
+devops_approval if {
 	"DevOps" in approvals[_].session.teams
 }
 
-security_approval {
+security_approval if {
 	"Security" in approvals[_].session.teams
 }
 
 # Approve when a single director approves:
-approve {
+approve if {
 	director_approval
 }
 
 # Approve when both DevOps and Security approve:
-approve {
+approve if {
 	devops_approval
 	security_approval
 }

--- a/examples/approval/role-based-approval.rego
+++ b/examples/approval/role-based-approval.rego
@@ -13,10 +13,6 @@ requires_approval if {
 	input.run.type == "TASK"
 }
 
-approve if {
-	not requires_approval
-}
-
 approvals := input.reviews.current.approvals
 
 # Let's define what it means to be approved by a director, DevOps and Security.
@@ -30,6 +26,10 @@ devops_approval if {
 
 security_approval if {
 	"Security" in approvals[_].session.teams
+}
+
+approve if {
+	not requires_approval
 }
 
 # Approve when a single director approves:

--- a/examples/approval/role-based-approval_test.rego
+++ b/examples/approval/role-based-approval_test.rego
@@ -1,42 +1,45 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test that a run in the "UNCONFIRMED" state requires approval
-test_unconfirmed_requires_approval {
-	requires_approval with input as {"run": {"state": "UNCONFIRMED"}}
+test_unconfirmed_requires_approval if {
+	spacelift.requires_approval with input as {"run": {"state": "UNCONFIRMED"}}
 }
 
 # Test that a run of type "TASK" requires approval
-test_task_requires_approval {
-	requires_approval with input as {"run": {"type": "TASK"}}
+test_task_requires_approval if {
+	spacelift.requires_approval with input as {"run": {"type": "TASK"}}
 }
 
 # Test that a run of type "TRACKED" and state "QUEUED" is auto-approved
-test_auto_approve {
-	approve with input as {
+test_auto_approve if {
+	spacelift.approve with input as {
 		"run": {"type": "TRACKED", "state": "QUEUED"},
 		"reviews": {"current": {"approvals": []}},
 	}
 }
 
 # Test that a run with a director's approval is approved
-test_director_approval {
-	approve with input as {
+test_director_approval if {
+	spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {"approvals": [{"session": {"teams": ["Director"]}}]}},
 	}
 }
 
 # Test that a run without a director's approval is not approved
-test_no_director_approval {
-	not approve with input as {
+test_no_director_approval if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {"approvals": [{"session": {"teams": ["Manager"]}}]}},
 	}
 }
 
 # Test that a run with both DevOps and Security approvals is approved
-test_devops_security_approval {
-	approve with input as {
+test_devops_security_approval if {
+	spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {"approvals": [
 			{"session": {"teams": ["DevOps"]}},
@@ -46,15 +49,15 @@ test_devops_security_approval {
 }
 
 # Test that a run with just DevOps or Security approval is not approved
-test_only_devops_approval {
-	not approve with input as {
+test_only_devops_approval if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {"approvals": [{"session": {"teams": ["DevOps"]}}]}},
 	}
 }
 
-test_only_security_approval {
-	not approve with input as {
+test_only_security_approval if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {"approvals": [{"session": {"teams": ["Security"]}}]}},
 	}

--- a/examples/approval/task-and-run-approvals.rego
+++ b/examples/approval/task-and-run-approvals.rego
@@ -3,6 +3,10 @@ package spacelift
 # This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
 import rego.v1
 
+# Autoapprove some task commands. Note how we don't check for run type
+# because only tasks will the have "command" field set.
+task_allowlist := ["ls", "ps"]
+
 # First, let's define all conditions that require explicit
 # user approval.
 requires_approval if {
@@ -18,12 +22,8 @@ approve if {
 	not requires_approval
 }
 
-# Autoapprove some task commands. Note how we don't check for run type
-# because only tasks will the have "command" field set.
-task_allowlist := ["ls", "ps"]
-
 approve if {
-	input.run.command == task_allowlist[_]
+	input.run.command in task_allowlist
 }
 
 # Two approvals and no rejections to approve.

--- a/examples/approval/task-and-run-approvals.rego
+++ b/examples/approval/task-and-run-approvals.rego
@@ -1,17 +1,20 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # First, let's define all conditions that require explicit
 # user approval.
-requires_approval {
+requires_approval if {
 	input.run.state == "UNCONFIRMED"
 }
 
-requires_approval {
+requires_approval if {
 	input.run.type == "TASK"
 }
 
 # Then, let's automatically approve all other jobs.
-approve {
+approve if {
 	not requires_approval
 }
 
@@ -19,12 +22,12 @@ approve {
 # because only tasks will the have "command" field set.
 task_allowlist := ["ls", "ps"]
 
-approve {
+approve if {
 	input.run.command == task_allowlist[_]
 }
 
 # Two approvals and no rejections to approve.
-approve {
+approve if {
 	count(input.reviews.current.approvals) > 1
 	count(input.reviews.current.rejections) == 0
 }

--- a/examples/approval/task-and-run-approvals_test.rego
+++ b/examples/approval/task-and-run-approvals_test.rego
@@ -1,18 +1,21 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test that a run in the "UNCONFIRMED" state requires approval
-test_unconfirmed_requires_approval {
-	requires_approval with input as {"run": {"state": "UNCONFIRMED"}}
+test_unconfirmed_requires_approval if {
+	spacelift.requires_approval with input as {"run": {"state": "UNCONFIRMED"}}
 }
 
 # Test that a run of type "TASK" requires approval
-test_task_requires_approval {
-	requires_approval with input as {"run": {"type": "TASK"}}
+test_task_requires_approval if {
+	spacelift.requires_approval with input as {"run": {"type": "TASK"}}
 }
 
 # Test that a run with command "ls" (from the task_allowlist) is approved
-test_ls_command_auto_approve {
-	approve with input as {
+test_ls_command_auto_approve if {
+	spacelift.approve with input as {
 		"run": {"command": "ls", "state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],
@@ -22,8 +25,8 @@ test_ls_command_auto_approve {
 }
 
 # Test that a run with command "ps" (from the task_allowlist) is approved
-test_ps_command_auto_approve {
-	approve with input as {
+test_ps_command_auto_approve if {
+	spacelift.approve with input as {
 		"run": {"command": "ps", "state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],
@@ -33,8 +36,8 @@ test_ps_command_auto_approve {
 }
 
 # Test that a run with command not in task_allowlist isn't automatically approved
-test_not_in_task_allowlist {
-	not approve with input as {
+test_not_in_task_allowlist if {
+	not spacelift.approve with input as {
 		"run": {"command": "mkdir", "state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],
@@ -44,8 +47,8 @@ test_not_in_task_allowlist {
 }
 
 # Test that a run with 2 approvals and 0 rejections is approved
-test_two_approvals_zero_rejections {
-	approve with input as {
+test_two_approvals_zero_rejections if {
+	spacelift.approve with input as {
 		"run": {"type": "TASK", "state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1", "user2"],
@@ -55,8 +58,8 @@ test_two_approvals_zero_rejections {
 }
 
 # Test that a run with 1 approval and 0 rejections isn't approved
-test_one_approval_zero_rejections {
-	not approve with input as {
+test_one_approval_zero_rejections if {
+	not spacelift.approve with input as {
 		"run": {"type": "TASK", "state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1"],
@@ -66,8 +69,8 @@ test_one_approval_zero_rejections {
 }
 
 # Test that a run with 2 approvals and 1 rejection isn't approved
-test_two_approvals_one_rejection {
-	not approve with input as {
+test_two_approvals_one_rejection if {
+	not spacelift.approve with input as {
 		"run": {"type": "TASK", "state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1", "user2"],

--- a/examples/approval/two-approvals-no-rejections.rego
+++ b/examples/approval/two-approvals-no-rejections.rego
@@ -1,15 +1,18 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # In this example, each Unconfirmed run will require two approvals -
 # including proposed runs triggered by Git events. Additionally,
 # the run should have no rejections. Anyone who rejects the run will
 # need to change their mind in order for the run to go through.
 
-approve {
+approve if {
 	input.run.state != "UNCONFIRMED"
 }
 
-approve {
+approve if {
 	count(input.reviews.current.approvals) > 1
 	count(input.reviews.current.rejections) == 0
 }

--- a/examples/approval/two-approvals-no-rejections_test.rego
+++ b/examples/approval/two-approvals-no-rejections_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test that a run in a state other than "UNCONFIRMED" is approved by the first rule
-test_other_than_unconfirmed_state_approved {
-	approve with input as {
+test_other_than_unconfirmed_state_approved if {
+	spacelift.approve with input as {
 		"run": {"state": "QUEUED"},
 		"reviews": {"current": {
 			"approvals": [],
@@ -12,8 +15,8 @@ test_other_than_unconfirmed_state_approved {
 }
 
 # Test that a run in the "UNCONFIRMED" state with 2 approvals and 0 rejections is approved by the second rule
-test_two_approvals_unconfirmed_state {
-	approve with input as {
+test_two_approvals_unconfirmed_state if {
+	spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1", "user2"],
@@ -23,8 +26,8 @@ test_two_approvals_unconfirmed_state {
 }
 
 # Test that a run in the "UNCONFIRMED" state with 1 approval and 0 rejections is not approved by the second rule
-test_one_approval_unconfirmed_state_not_approved {
-	not approve with input as {
+test_one_approval_unconfirmed_state_not_approved if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1"],
@@ -34,8 +37,8 @@ test_one_approval_unconfirmed_state_not_approved {
 }
 
 # Test that a run in the "UNCONFIRMED" state with 0 approvals and 1 rejection is not approved by the second rule
-test_one_rejection_unconfirmed_state_not_approved {
-	not approve with input as {
+test_one_rejection_unconfirmed_state_not_approved if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],

--- a/examples/approval/two-approvals-two-rejections.rego
+++ b/examples/approval/two-approvals-two-rejections.rego
@@ -1,19 +1,22 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # In this example, each Unconfirmed run will require two approvals -
 # including proposed runs triggered by Git events. Additionally,
 # the run should not have more than one rejection. Everyone who rejects the run will
 # need to change their mind in order for the run to go through.
 
-approve {
+approve if {
 	input.run.state != "UNCONFIRMED"
 }
 
-approve {
+approve if {
 	count(input.reviews.current.approvals) > 1
 }
 
-reject {
+reject if {
 	count(input.reviews.current.rejections) > 1
 }
 

--- a/examples/approval/two-approvals-two-rejections_test.rego
+++ b/examples/approval/two-approvals-two-rejections_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test that a run in the "UNCONFIRMED" state is not approved
-test_unconfirmed_run_not_approved {
-	not approve with input as {
+test_unconfirmed_run_not_approved if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],
@@ -12,8 +15,8 @@ test_unconfirmed_run_not_approved {
 }
 
 # Test that a run with 2 approvals is approved
-test_two_approvals {
-	approve with input as {
+test_two_approvals if {
+	spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1", "user2"],
@@ -23,8 +26,8 @@ test_two_approvals {
 }
 
 # Test that a run with 1 approval is not approved
-test_one_approval_not_enough {
-	not approve with input as {
+test_one_approval_not_enough if {
+	not spacelift.approve with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": ["user1"],
@@ -34,8 +37,8 @@ test_one_approval_not_enough {
 }
 
 # Test that a run with more than 1 rejection is rejected
-test_more_than_one_rejection {
-	reject with input as {
+test_more_than_one_rejection if {
+	spacelift.reject with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],
@@ -45,8 +48,8 @@ test_more_than_one_rejection {
 }
 
 # Test that a run with 1 rejection is not rejected
-test_one_rejection {
-	not reject with input as {
+test_one_rejection if {
+	not spacelift.reject with input as {
 		"run": {"state": "UNCONFIRMED"},
 		"reviews": {"current": {
 			"approvals": [],

--- a/examples/login/access-levels-within-an-organization.rego
+++ b/examples/login/access-levels-within-an-organization.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This login policy gives everyone in the organization access to Spacelift
 # and makes all members of the "DevOps" team admins.
@@ -8,15 +9,15 @@ import future.keywords.in
 # You can read more about login policies here:
 # https://docs.spacelift.io/concepts/policy/login-policy
 
-admin {
+admin if {
 	"DevOps" in input.session.teams
 }
 
-allow {
+allow if {
 	input.session.member
 }
 
-deny {
+deny if {
 	not allow
 }
 

--- a/examples/login/external-contributor-access-github.rego
+++ b/examples/login/external-contributor-access-github.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # NOTE: This feature is not available when using single sign-on -
 # your identity provider must be able to successfully validate each user
 # trying to log in to Spacelift.
@@ -17,15 +20,15 @@ allowed := {"bob", "charlie", "danny"}
 
 login := input.session.login
 
-admin {
+admin if {
 	admins[login]
 }
 
-allow {
+allow if {
 	allowed[login]
 }
 
-deny {
+deny if {
 	not admins[login]
 	not allowed[login]
 }

--- a/examples/login/external-contributor-access-google.rego
+++ b/examples/login/external-contributor-access-google.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # NOTE: This feature is not available when using single sign-on -
 # your identity provider must be able to successfully validate each user
 # trying to log in to Spacelift.
@@ -13,15 +16,15 @@ admins := {"alice@example.com"}
 
 login := input.session.login
 
-admin {
+admin if {
 	admins[login]
 }
 
-allow {
+allow if {
 	endswith(input.session.login, "@example.com")
 }
 
-deny {
+deny if {
 	not admins[login]
 	not allow
 }

--- a/examples/login/readers-writers-admins-teams.rego
+++ b/examples/login/readers-writers-admins-teams.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # Define team roles
 admins := {"team1", "team2", "team3"}

--- a/examples/login/readers-writers-admins-teams_test.rego
+++ b/examples/login/readers-writers-admins-teams_test.rego
@@ -1,10 +1,9 @@
 package spacelift_test
 
+import rego.v1
+
 # Import the spacelift package to access its rules.
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 test_allow_writers if {
 	spacelift.space_write with input as {"session": {"teams": ["team4"]}}

--- a/examples/login/rewriting-user-teams.rego
+++ b/examples/login/rewriting-user-teams.rego
@@ -1,10 +1,11 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This rule will copy each of the existing teams to the new modified list.
 # Remove it if you want to start from scratch.
-team[input.session.teams[_]]
+team contains input.session.teams[_]
 
 # In addition to boolean rules regulating access to your Spacelift account, the login
 # policy exposes the team rule, which allows one to dynamically rewrite the list of teams
@@ -15,21 +16,21 @@ team[input.session.teams[_]]
 # - is a member of the DevOps team, as defined by your IdP;
 # - is not a member of the Contractors team, as defined by your IdP;
 
-team["Superwriter"] {
+team contains "Superwriter" if {
 	office_vpn
 	devops
 	not contractor
 }
 
-contractor {
+contractor if {
 	"Contractors" in input.session.teams
 }
 
-devops {
+devops if {
 	"DevOps" in input.session.teams
 }
 
-office_vpn {
+office_vpn if {
 	net.cidr_contains("12.34.56.0/24", input.request.remote_ip)
 }
 

--- a/examples/login/who-when-where-login-restrictions.rego
+++ b/examples/login/who-when-where-login-restrictions.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # The example below is pretty extreme but it shows a very comprehensive
 # policy where you restrict Spacelift access to users logging in from the office IP
 # during business hours. You may want to use elements of this policy to create your own
@@ -20,21 +23,21 @@ ip := input.request.remote_ip
 # for who can have write access, when, and from where (the ip)
 #
 # Only allow access during weekdays
-deny {
+deny if {
 	weekend[weekday]
 }
 
 # Only allow access during 9-5 time zone
-deny {
+deny if {
 	clock[0] < 9
 }
 
-deny {
+deny if {
 	clock[0] > 17
 }
 
 # Only allow access from the 12.34.56.0/24 CIDR
-deny {
+deny if {
 	not net.cidr_contains("12.34.56.0/24", ip)
 }
 

--- a/examples/notification/drift-detection-with-changes.rego
+++ b/examples/notification/drift-detection-with-changes.rego
@@ -1,6 +1,9 @@
 package spacelift
 
-slack[{"channel_id": "C000000"}] {
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
+slack contains {"channel_id": "C000000"} if {
 	# Checking if drift detection is present in the run update
 	input.run_updated.run.drift_detection
 

--- a/examples/notification/drift-detection-with-changes_test.rego
+++ b/examples/notification/drift-detection-with-changes_test.rego
@@ -1,32 +1,35 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test when drift detection is present and there's at least one change
-test_slack_trigger_for_drift_and_changes {
-	count(slack) == 1 with input as {"run_updated": {"run": {
+test_slack_trigger_for_drift_and_changes if {
+	count(spacelift.slack) == 1 with input as {"run_updated": {"run": {
 		"drift_detection": true,
 		"changes": [{"change": "example_change_1"}],
 	}}}
 }
 
 # Test when drift detection is not present but there's at least one change
-test_no_slack_trigger_for_no_drift_but_changes {
-	count(slack) == 0 with input as {"run_updated": {"run": {
+test_no_slack_trigger_for_no_drift_but_changes if {
+	count(spacelift.slack) == 0 with input as {"run_updated": {"run": {
 		"drift_detection": false,
 		"changes": [{"change": "example_change_1"}],
 	}}}
 }
 
 # Test when drift detection is present but there are no changes
-test_no_slack_trigger_for_drift_but_no_changes {
-	count(slack) == 0 with input as {"run_updated": {"run": {
+test_no_slack_trigger_for_drift_but_no_changes if {
+	count(spacelift.slack) == 0 with input as {"run_updated": {"run": {
 		"drift_detection": true,
 		"changes": [],
 	}}}
 }
 
 # Test when both drift detection isn't present and there are no changes
-test_no_slack_trigger_for_no_drift_and_no_changes {
-	count(slack) == 0 with input as {"run_updated": {"run": {
+test_no_slack_trigger_for_no_drift_and_no_changes if {
+	count(spacelift.slack) == 0 with input as {"run_updated": {"run": {
 		"drift_detection": false,
 		"changes": [],
 	}}}

--- a/examples/notification/notification-failure.rego
+++ b/examples/notification/notification-failure.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 ir := input.run_updated
 

--- a/examples/notification/notification-failure_test.rego
+++ b/examples/notification/notification-failure_test.rego
@@ -1,13 +1,12 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test Case 1: Run failed with 'deny' outcome
 test_run_failed_with_deny if {
-	input := {
+	test_input := {
 		"account": {"name": "<example>"},
 		"run_updated": {
 			"run": {"state": "FAILED", "id": "run123"},
@@ -15,13 +14,13 @@ test_run_failed_with_deny if {
 			"policy_receipts": [{"name": "deny_policy", "outcome": "deny"}],
 		},
 	}
-	result := spacelift.slack with input as input
+	result := spacelift.slack with input as test_input
 	count(result) == 1
 }
 
 # Test Case 2: Run failed with 'reject' outcome
 test_run_failed_with_reject if {
-	input := {
+	test_input := {
 		"account": {"name": "<example>"},
 		"run_updated": {
 			"run": {"state": "FAILED", "id": "run123"},
@@ -29,13 +28,13 @@ test_run_failed_with_reject if {
 			"policy_receipts": [{"name": "reject_policy", "outcome": "reject"}],
 		},
 	}
-	result := spacelift.slack with input as input
+	result := spacelift.slack with input as test_input
 	count(result) == 1
 }
 
 # Test Case 3: Run failed with neither 'deny' nor 'reject' outcome
 test_run_failed_with_neither if {
-	input := {
+	test_input := {
 		"account": {"name": "<example>"},
 		"run_updated": {
 			"run": {"state": "FAILED", "id": "run123"},
@@ -43,13 +42,13 @@ test_run_failed_with_neither if {
 			"policy_receipts": [{"name": "null", "outcome": null}],
 		},
 	}
-	result := spacelift.slack with input as input
+	result := spacelift.slack with input as test_input
 	count(result) == 1
 }
 
 # Test Case 4: Run has not failed
 test_run_not_failed if {
-	input := {
+	test_input := {
 		"account": {"name": "<example>"},
 		"run_updated": {
 			"run": {"state": "PASSED", "id": "run123"},
@@ -57,6 +56,6 @@ test_run_not_failed if {
 			"policy_receipts": [{"name": "some_policy", "outcome": "deny"}],
 		},
 	}
-	result := spacelift.slack with input as input
+	result := spacelift.slack with input as test_input
 	count(result) == 0
 }

--- a/examples/notification/notification-stack-failure-origins.rego
+++ b/examples/notification/notification-stack-failure-origins.rego
@@ -2,8 +2,8 @@
 
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 run_url := sprintf(
 	"https://%s.app.spacelift.io/stack/%s/run/%s",

--- a/examples/notification/notification-stack-failure-origins_test.rego
+++ b/examples/notification/notification-stack-failure-origins_test.rego
@@ -1,10 +1,7 @@
-package spacelift
-
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+package spacelift_test
 
 import data.spacelift
+import rego.v1
 
 # Test successful Slack notification for a tracked, failed run
 test_slack_notification_for_tracked_failed_run if {

--- a/examples/notification/pull-request-comment-summary.rego
+++ b/examples/notification/pull-request-comment-summary.rego
@@ -1,9 +1,7 @@
-# regal ignore:use-rego-v1
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # regal ignore:line-length
 header := sprintf("### Resource changes ([link](%s))\n\n![add](https://img.shields.io/badge/add-%d-brightgreen) ![change](https://img.shields.io/badge/change-%d-yellow) ![destroy](https://img.shields.io/badge/destroy-%d-red) ![import](https://img.shields.io/badge/import-%d-blue) ![move](https://img.shields.io/badge/move-%d-purple) ![forget](https://img.shields.io/badge/forget-%d-b07878) \n\n| Action | Resource | Changes |\n| --- | --- | --- |", [input.run_updated.urls.run, count(added), count(changed), count(deleted), count(imported), count(moved), count(forgotten)])

--- a/examples/notification/pull-request-comment-summary_test.rego
+++ b/examples/notification/pull-request-comment-summary_test.rego
@@ -1,10 +1,8 @@
-# regal ignore:use-rego-v1
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test with 1 resource having "create-before-destroy" action with moved false
 test_create_before_destroy if {
@@ -33,11 +31,11 @@ test_create_before_destroy if {
 	# Get the added resources with the input data applied
 	added_resources := spacelift.added with input as input_data
 
-	# Get the deleted resources with the input data applied
-	deleted_resources := spacelift.deleted with input as input_data
-
 	# Correct count for added resources
 	count(added_resources) == 1
+
+	# Get the deleted resources with the input data applied
+	deleted_resources := spacelift.deleted with input as input_data
 
 	# Correct count for deleted resources
 	count(deleted_resources) == 1
@@ -91,11 +89,11 @@ test_added_and_moved_resources if {
 	# Get the added resources with the input data applied
 	added_resources := spacelift.added with input as input_data
 
-	# Get the moved resources with the input data applied
-	moved_resources := spacelift.moved with input as input_data
-
 	# Correct count for added resources
 	count(added_resources) == 2
+
+	# Get the moved resources with the input data applied
+	moved_resources := spacelift.moved with input as input_data
 
 	# Correct count for moved resources
 	count(moved_resources) == 1

--- a/examples/notification/slack-channels-with-labels.rego
+++ b/examples/notification/slack-channels-with-labels.rego
@@ -1,7 +1,10 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This rule will generate an array of Slack channel names from the stack labels.
-slack_channels[slack_channel] {
+slack_channels contains slack_channel if {
 	# Extract labels from the stack
 	label := input.run_updated.stack.labels[_]
 
@@ -12,7 +15,7 @@ slack_channels[slack_channel] {
 	slack_channel := split(label, ":")[1]
 }
 
-slack[{"channel_id": channel}] {
+slack contains {"channel_id": channel} if {
 	run := input.run_updated.run
 	run.type == "TRACKED"
 

--- a/examples/notification/slack-channels-with-labels.rego
+++ b/examples/notification/slack-channels-with-labels.rego
@@ -21,7 +21,7 @@ slack contains {"channel_id": channel} if {
 
 	# Here we're using the slack_channels rule to get all channels
 	# and iterate over each one.
-	channel = slack_channels[_]
+	some channel in slack_channels
 }
 
 sample := true

--- a/examples/notification/slack-channels-with-labels_test.rego
+++ b/examples/notification/slack-channels-with-labels_test.rego
@@ -1,10 +1,11 @@
-package spacelift
+package spacelift_test
 
-import future.keywords.in
+import data.spacelift
+import rego.v1
 
 # 1. Label with the right format triggers slack rule
-test_single_label_triggers_slack {
-	result := slack with input as {"run_updated": {
+test_single_label_triggers_slack if {
+	result := spacelift.slack with input as {"run_updated": {
 		"stack": {"labels": ["slack:C12345678"]},
 		"run": {"type": "TRACKED"},
 	}}
@@ -13,8 +14,8 @@ test_single_label_triggers_slack {
 }
 
 # 2. Two labels in the right format should trigger slack rule twice
-test_two_labels_trigger_slack_twice {
-	result := slack with input as {"run_updated": {
+test_two_labels_trigger_slack_twice if {
+	result := spacelift.slack with input as {"run_updated": {
 		"stack": {"labels": [
 			"slack:C12345678",
 			"slack:C89101112",
@@ -27,8 +28,8 @@ test_two_labels_trigger_slack_twice {
 }
 
 # 3. Label not in the right format should not trigger slack rule
-test_wrong_format_doesnt_trigger_slack {
-	result := slack with input as {"run_updated": {
+test_wrong_format_doesnt_trigger_slack if {
+	result := spacelift.slack with input as {"run_updated": {
 		"stack": {"labels": ["slackXYZ:C12345678"]},
 		"run": {"type": "TRACKED"},
 	}}

--- a/examples/plan/check-blast-radius.rego
+++ b/examples/plan/check-blast-radius.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy attempts to create a metric called a "blast radius" - that is how much the change will affect the whole stack.
 # It assigns special multipliers to some types of resources changed and treats different types of changes differently:
 # deletes and updates are more "expensive" because they affect live resources, while new resources are generally safer
@@ -8,17 +11,17 @@ package spacelift
 
 proposed := input.spacelift.run.type == "PROPOSED"
 
-deny[msg] {
+deny contains msg if {
 	proposed
 	msg := blast_radius_too_high[_]
 }
 
-warn[msg] {
+warn contains msg if {
 	not proposed
 	msg := blast_radius_too_high[_]
 }
 
-blast_radius_too_high[sprintf("change blast radius too high (%d/100)", [blast_radius])] {
+blast_radius_too_high contains sprintf("change blast radius too high (%d/100)", [blast_radius]) if {
 	blast_radius := sum([blast |
 		resource := input.terraform.resource_changes[_]
 		blast := blast_radius_for_resource(resource)
@@ -27,7 +30,7 @@ blast_radius_too_high[sprintf("change blast radius too high (%d/100)", [blast_ra
 	blast_radius > 100
 }
 
-blast_radius_for_resource(resource) := ret {
+blast_radius_for_resource(resource) := ret if {
 	blasts_radii_by_action := {"delete": 10, "update": 5, "create": 1, "no-op": 0}
 
 	ret := sum([value |
@@ -42,7 +45,7 @@ blast_radius_for_resource(resource) := ret {
 blasts_radii_by_type := {"aws_ecs_cluster": 20, "aws_ecs_user": 10, "aws_ecs_role": 5}
 
 # By default, blast radius has a value of 1.
-blast_radius_for_type(type) := 1 {
+blast_radius_for_type(type) := 1 if {
 	not blasts_radii_by_type[type]
 }
 

--- a/examples/plan/check-blast-radius_test.rego
+++ b/examples/plan/check-blast-radius_test.rego
@@ -1,7 +1,10 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for blast radius below threshold for tracked run.
-test_check_blast_radius_below_threshold_tracked_run {
+test_check_blast_radius_below_threshold_tracked_run if {
 	inp := {
 		"spacelift": {"run": {"type": "TRACKED"}},
 		"terraform": {"resource_changes": [{
@@ -10,12 +13,12 @@ test_check_blast_radius_below_threshold_tracked_run {
 			"change": {"actions": ["delete"]},
 		}]},
 	}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test case for blast radius below threshold for proposed run.
-test_check_blast_radius_below_threshold_proposed_run {
+test_check_blast_radius_below_threshold_proposed_run if {
 	inp := {
 		"spacelift": {"run": {"type": "PROPOSED"}},
 		"terraform": {"resource_changes": [{
@@ -24,12 +27,12 @@ test_check_blast_radius_below_threshold_proposed_run {
 			"change": {"actions": ["delete"]},
 		}]},
 	}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test case for blast radius threshold exceeded for tracked run.
-test_check_blast_radius_threshold_exceeded_tracked_run {
+test_check_blast_radius_threshold_exceeded_tracked_run if {
 	inp := {
 		"spacelift": {"run": {"type": "TRACKED"}},
 		"terraform": {"resource_changes": [{
@@ -38,12 +41,12 @@ test_check_blast_radius_threshold_exceeded_tracked_run {
 			"change": {"actions": ["delete"]},
 		}]},
 	}
-	warn["change blast radius too high (200/100)"] with input as inp
-	count(deny) == 0 with input as inp
+	spacelift.warn["change blast radius too high (200/100)"] with input as inp
+	count(spacelift.deny) == 0 with input as inp
 }
 
 # Test case for blast radius threshold exceeded for proposed run.
-test_check_blast_radius_threshold_exceeded_proposed_run {
+test_check_blast_radius_threshold_exceeded_proposed_run if {
 	inp := {
 		"spacelift": {"run": {"type": "PROPOSED"}},
 		"terraform": {"resource_changes": [{
@@ -52,6 +55,6 @@ test_check_blast_radius_threshold_exceeded_proposed_run {
 			"change": {"actions": ["delete"]},
 		}]},
 	}
-	deny["change blast radius too high (200/100)"] with input as inp
-	count(warn) == 0 with input as inp
+	spacelift.deny["change blast radius too high (200/100)"] with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }

--- a/examples/plan/check-sanitized-value.rego
+++ b/examples/plan/check-sanitized-value.rego
@@ -1,10 +1,13 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Sensitive properties in "before" and "after" objects will be sanitized to protect secret values.
 # Sanitization hashes the value and takes the last 8 bytes of the hash.
 # If you need to compare a string property to a constant, you can use the sanitized(string) helper function.
 
-deny["must not target the forbidden endpoint: forbidden.endpoint/webhook"] {
+deny contains "must not target the forbidden endpoint: forbidden.endpoint/webhook" if {
 	resource := input.terraform.resource_changes[_]
 
 	actions := {"create", "delete", "update"}

--- a/examples/plan/checkov-failed-checks.rego
+++ b/examples/plan/checkov-failed-checks.rego
@@ -1,8 +1,11 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy will give you a warning if your failed checks are less than 10, but will not fail your run.
 
-warn[sprintf(message, [p])] {
+warn contains sprintf(message, [p]) if {
 	message := "You have a couple of failed checks: %d"
 	results := input.third_party_metadata.custom.checkov.results.failed_checks
 	p := count(results)

--- a/examples/plan/checkov-failed-checks_test.rego
+++ b/examples/plan/checkov-failed-checks_test.rego
@@ -1,7 +1,10 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test for failed checkov checks.
-test_checkov_less_than_10_failed_checks {
+test_checkov_less_than_10_failed_checks if {
 	inp := {"third_party_metadata": {"custom": {"checkov": {"results": {"failed_checks": [
 		{"check_id": "CKV_AWS_1"},
 		{"check_id": "CKV_AWS_2"},
@@ -13,9 +16,9 @@ test_checkov_less_than_10_failed_checks {
 		{"check_id": "CKV_AWS_8"},
 		{"check_id": "CKV_AWS_9"},
 	]}}}}}
-	warn["You have a couple of failed checks: 9"] with input as inp
+	spacelift.warn["You have a couple of failed checks: 9"] with input as inp
 }
 
-test_checkov_no_failed_checks {
-	count(warn) == 0 with input as {}
+test_checkov_no_failed_checks if {
+	count(spacelift.warn) == 0 with input as {}
 }

--- a/examples/plan/deny-proposed-runs-warn-track-runs.rego
+++ b/examples/plan/deny-proposed-runs-warn-track-runs.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # The best way to use warn and deny rules together depends on your preferred Git workflow.
 # We've found short-lived feature branches with Pull Requests to the tracked branch to work relatively well.
@@ -22,17 +23,17 @@ import future.keywords.in
 
 proposed := input.spacelift.run.type == "PROPOSED"
 
-deny[reason] {
+deny contains reason if {
 	proposed
 	reason := iam_user_created[_]
 }
 
-warn[reason] {
+warn contains reason if {
 	not proposed
 	reason := iam_user_created[_]
 }
 
-iam_user_created[sprintf("Do not create IAM users: (%s)", [resource.address])] {
+iam_user_created contains sprintf("Do not create IAM users: (%s)", [resource.address]) if {
 	resource := input.terraform.resource_changes[_]
 	"create" in resource.change.actions
 

--- a/examples/plan/deny-proposed-runs-warn-track-runs_test.rego
+++ b/examples/plan/deny-proposed-runs-warn-track-runs_test.rego
@@ -1,7 +1,10 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case warning for a tracked run.
-test_warn_tracked_runs {
+test_warn_tracked_runs if {
 	inp := {
 		"spacelift": {"run": {"type": "TRACKED"}},
 		"terraform": {"resource_changes": [{
@@ -10,12 +13,12 @@ test_warn_tracked_runs {
 			"change": {"actions": ["create"]},
 		}]},
 	}
-	count(deny) == 0 with input as inp
-	warn["Do not create IAM users: (aws_iam_user.user_1)"] with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	spacelift.warn["Do not create IAM users: (aws_iam_user.user_1)"] with input as inp
 }
 
 # Test case deny for a proposed run.
-test_deny_proposed_runs {
+test_deny_proposed_runs if {
 	inp := {
 		"spacelift": {"run": {"type": "PROPOSED"}},
 		"terraform": {"resource_changes": [{
@@ -24,6 +27,6 @@ test_deny_proposed_runs {
 			"change": {"actions": ["create"]},
 		}]},
 	}
-	count(warn) == 0 with input as inp
-	deny["Do not create IAM users: (aws_iam_user.user_1)"] with input as inp
+	count(spacelift.warn) == 0 with input as inp
+	spacelift.deny["Do not create IAM users: (aws_iam_user.user_1)"] with input as inp
 }

--- a/examples/plan/do-not-delete-stateful-resources.rego
+++ b/examples/plan/do-not-delete-stateful-resources.rego
@@ -1,13 +1,14 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy is a plan policy, it will validate the resources during the plan phase.
 # More details at: https://docs.spacelift.io/concepts/policy/terraform-plan-policy
 # The "deny" rule fires when a specified resource is being deleted.
 # The result is a formatted message with the address of the offending resource.
 
-deny[sprintf(message, [resource.address])] {
+deny contains sprintf(message, [resource.address]) if {
 	# Define the error message format
 	message := "do not delete %s"
 

--- a/examples/plan/do-not-delete-stateful-resources_test.rego
+++ b/examples/plan/do-not-delete-stateful-resources_test.rego
@@ -1,9 +1,12 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for an aws_s3_bucket being deleted
-test_deny_s3_bucket_deletion {
+test_deny_s3_bucket_deletion if {
 	# Assert deny rule fires with the expected message
-	deny["do not delete aws_s3_bucket.my_bucket"] with input as {"terraform": {"resource_changes": [{
+	spacelift.deny["do not delete aws_s3_bucket.my_bucket"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_s3_bucket.my_bucket",
 		"type": "aws_s3_bucket",
 		"change": {"actions": ["delete"]},
@@ -11,9 +14,9 @@ test_deny_s3_bucket_deletion {
 }
 
 # Test case for an aws_db_instance being deleted
-test_deny_db_instance_deletion {
+test_deny_db_instance_deletion if {
 	# Assert deny rule fires with the expected message
-	deny["do not delete aws_db_instance.my_rds"] with input as {"terraform": {"resource_changes": [{
+	spacelift.deny["do not delete aws_db_instance.my_rds"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_db_instance.my_rds",
 		"type": "aws_db_instance",
 		"change": {"actions": ["delete"]},
@@ -21,9 +24,9 @@ test_deny_db_instance_deletion {
 }
 
 # Test case for an aws_efs_file_system being deleted
-test_deny_efs_file_system_deletion {
+test_deny_efs_file_system_deletion if {
 	# Assert deny rule fires with the expected message
-	deny["do not delete aws_efs_file_system.my_efs"] with input as {"terraform": {"resource_changes": [{
+	spacelift.deny["do not delete aws_efs_file_system.my_efs"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_efs_file_system.my_efs",
 		"type": "aws_efs_file_system",
 		"change": {"actions": ["delete"]},
@@ -31,9 +34,9 @@ test_deny_efs_file_system_deletion {
 }
 
 # Test case for an aws_dynamodb_table being deleted
-test_deny_dynamodb_table_deletion {
+test_deny_dynamodb_table_deletion if {
 	# Assert deny rule fires with the expected message
-	deny["do not delete aws_dynamodb_table.my_table"] with input as {"terraform": {"resource_changes": [{
+	spacelift.deny["do not delete aws_dynamodb_table.my_table"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_dynamodb_table.my_table",
 		"type": "aws_dynamodb_table",
 		"change": {"actions": ["delete"]},
@@ -41,9 +44,9 @@ test_deny_dynamodb_table_deletion {
 }
 
 # Test case for an aws_instance being deleted (which should not be denied)
-test_allow_instance_deletion {
+test_allow_instance_deletion if {
 	# Assert deny rule does not fire
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_instance.my_instance",
 		"type": "aws_instance",
 		"change": {"actions": ["delete"]},

--- a/examples/plan/dont-allow-resource-type.rego
+++ b/examples/plan/dont-allow-resource-type.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # Note that the message here is dynamic and captures resource address to provide
 # appropriate context to anyone affected by this policy. For the sake of your
@@ -9,7 +10,7 @@ import future.keywords.in
 # You can read more about plan policies here:
 # https://docs.spacelift.io/concepts/policy/terraform-plan-policy
 
-deny[sprintf(message, [resource.address])] {
+deny contains sprintf(message, [resource.address]) if {
 	message := "Static AWS credentials are evil (%s)"
 
 	resource := input.terraform.resource_changes[_]

--- a/examples/plan/dont-allow-resource-type_test.rego
+++ b/examples/plan/dont-allow-resource-type_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying creation of resource type.
-test_deny_creation_of_resource_type {
-	deny["Static AWS credentials are evil (aws_iam_access_key.key_1)"] with input as {"terraform": {"resource_changes": [{
+test_deny_creation_of_resource_type if {
+	spacelift.deny["Static AWS credentials are evil (aws_iam_access_key.key_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_access_key.key_1",
 		"type": "aws_iam_access_key",
 		"change": {"actions": ["create"]},

--- a/examples/plan/enforce-cloud-provider.rego
+++ b/examples/plan/enforce-cloud-provider.rego
@@ -1,10 +1,13 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # While in most cases you'll want your rules to only look at resources affected by the change,
 # you're not limited to doing so. You can also look at all resources and force teams to remove certain resources.
 # Here's an example - until all AWS resources are removed all in one go, no further changes can take place.
 
-deny[sprintf(message, [resource.address])] {
+deny contains sprintf(message, [resource.address]) if {
 	message := "We have moved to GCP, find an equivalent there (%s)"
 	resource := input.terraform.resource_changes[_]
 

--- a/examples/plan/enforce-cloud-provider_test.rego
+++ b/examples/plan/enforce-cloud-provider_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying creation of aws resources.
-test_deny_creation_of_aws_resource {
-	deny["We have moved to GCP, find an equivalent there (aws_iam_access_key.key_1)"] with input as {"terraform": {"resource_changes": [{
+test_deny_creation_of_aws_resource if {
+	spacelift.deny["We have moved to GCP, find an equivalent there (aws_iam_access_key.key_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_access_key.key_1",
 		"type": "aws_iam_access_key",
 		"change": {"actions": ["create"]},
@@ -11,11 +14,11 @@ test_deny_creation_of_aws_resource {
 }
 
 # Test case for allowing deletion of aws resources.
-test_allow_deletion_of_aws_resource {
+test_allow_deletion_of_aws_resource if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_iam_access_key.key_1",
 		"type": "aws_iam_access_key",
 		"change": {"actions": ["update"]},
 	}]}}
-	count(deny) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
 }

--- a/examples/plan/enforce-instance-type-list.rego
+++ b/examples/plan/enforce-instance-type-list.rego
@@ -33,16 +33,12 @@ warn contains sprintf(message, [resource.address, instance]) if {
 
 # Helper function to check if instance type is in the allow list
 is_in_allow_list(instance) if {
-	some allowed_instance
-	allowed_instance = allow_list[_]
-	allowed_instance == instance
+	instance in allow_list
 }
 
 # Helper function to check if instance type is in the deny list
 is_in_deny_list(instance) if {
-	some denied_instance
-	denied_instance = deny_list[_]
-	denied_instance == instance
+	instance in deny_list
 }
 
 # Learn more about sampling policy evaluations here:

--- a/examples/plan/enforce-instance-type-list.rego
+++ b/examples/plan/enforce-instance-type-list.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Smart Sanitization should be enabled on the stack so the policy can correctly read
 # the instance type.
 
@@ -10,7 +13,7 @@ deny_list := ["t2.2xlarge", "t2.xlarge"]
 allow_list := ["t2.nano", "t2.micro", "t2.small"]
 
 # Deny if the instance type is in the deny list
-deny[sprintf(message, [resource.address, instance])] {
+deny contains sprintf(message, [resource.address, instance]) if {
 	message := "Instance type %s is not allowed (%s)"
 	resource := input.terraform.resource_changes[_]
 	resource.type == "aws_instance"
@@ -19,7 +22,7 @@ deny[sprintf(message, [resource.address, instance])] {
 }
 
 # Warn if the instance type is not in the allow or deny lists
-warn[sprintf(message, [resource.address, instance])] {
+warn contains sprintf(message, [resource.address, instance]) if {
 	message := "Instance type %s is not recommended (%s)"
 	resource := input.terraform.resource_changes[_]
 	resource.type == "aws_instance"
@@ -29,14 +32,14 @@ warn[sprintf(message, [resource.address, instance])] {
 }
 
 # Helper function to check if instance type is in the allow list
-is_in_allow_list(instance) {
+is_in_allow_list(instance) if {
 	some allowed_instance
 	allowed_instance = allow_list[_]
 	allowed_instance == instance
 }
 
 # Helper function to check if instance type is in the deny list
-is_in_deny_list(instance) {
+is_in_deny_list(instance) if {
 	some denied_instance
 	denied_instance = deny_list[_]
 	denied_instance == instance

--- a/examples/plan/enforce-instance-type-list_test.rego
+++ b/examples/plan/enforce-instance-type-list_test.rego
@@ -1,64 +1,67 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test for denied instances
-test_deny_t2_2xlarge {
+test_deny_t2_2xlarge if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.2xlarge"}},
 	}]}}
-	count(deny) == 1 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 1 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_deny_t2_xlarge {
+test_deny_t2_xlarge if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.xlarge"}},
 	}]}}
-	count(deny) == 1 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 1 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test for allowed instances (should not warn or deny)
-test_allow_t2_micro {
+test_allow_t2_micro if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.micro"}},
 	}]}}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_allow_t2_small {
+test_allow_t2_small if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.small"}},
 	}]}}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_allow_t2_nano {
+test_allow_t2_nano if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.nano"}},
 	}]}}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test for instances that should generate a warning
-test_warn_t2_medium {
+test_warn_t2_medium if {
 	inp := {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"after": {"instance_type": "t2.medium"}},
 	}]}}
-	count(deny) == 0 with input as inp
-	count(warn) == 1 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 1 with input as inp
 }

--- a/examples/plan/enforce-module-use-policy.rego
+++ b/examples/plan/enforce-module-use-policy.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # Note:  This policy requires the configuration of your terraform state to be provided.  In this policy,
 # we reference this via `input.third_party_metadata.custom.configuration` (line 56 below)
@@ -21,7 +22,7 @@ controlled_resource_types := {
 }
 
 # Deny ability to create the resource directly (aka not in a module we identify)
-deny[reason] {
+deny contains reason if {
 	resource := input.terraform.resource_changes[_]
 	actions := {"create", "update"}
 	actions[resource.change.actions[_]]
@@ -34,7 +35,7 @@ deny[reason] {
 }
 
 # Deny ability to create the resource in an unapproved module
-deny[failed_reasons] {
+deny contains failed_reasons if {
 	# Did any of the resources fail to pass?
 	count(invalid_resources[_]) > 0
 
@@ -49,7 +50,7 @@ deny[failed_reasons] {
 
 # Walk the "configuration" tree and find all the resources which appear in our
 # "controlled_resource_types"
-controlled_resources[resource] {
+controlled_resources contains resource if {
 	# Recursively walk the module hierarchy
 	[path, module_ref] := walk(input.third_party_metadata.custom.configuration)
 
@@ -75,7 +76,7 @@ controlled_resources[resource] {
 
 # When the controlled resources are collected, iterate through them and
 # see if they comply
-invalid_resources[resource_instance] {
+invalid_resources contains resource_instance if {
 	resource_instance := controlled_resources[_]
 	not resource_instance.resource_module_name in controlled_resource_types[resource_instance.resource_type]
 }

--- a/examples/plan/enforce-module-use-policy_test.rego
+++ b/examples/plan/enforce-module-use-policy_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying creation of controlled resource type.
-test_deny_creation_of_controlled_resource_type {
-	deny["Resource 'aws_s3_bucket.bucket_1' cannot be created directly. Module(s) 'terraform-aws-modules/s3-bucket/aws' must be used instead"] with input as {"terraform": {"resource_changes": [{
+test_deny_creation_of_controlled_resource_type if {
+	spacelift.deny["Resource 'aws_s3_bucket.bucket_1' cannot be created directly. Module(s) 'terraform-aws-modules/s3-bucket/aws' must be used instead"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_s3_bucket.bucket_1",
 		"type": "aws_s3_bucket",
 		"change": {"actions": ["create"]},
@@ -10,8 +13,8 @@ test_deny_creation_of_controlled_resource_type {
 }
 
 # Test case for update creation of controlled resource type.
-test_deny_update_of_controlled_resource_type {
-	deny["Resource 'aws_s3_bucket.bucket_1' cannot be created directly. Module(s) 'terraform-aws-modules/s3-bucket/aws' must be used instead"] with input as {"terraform": {"resource_changes": [{
+test_deny_update_of_controlled_resource_type if {
+	spacelift.deny["Resource 'aws_s3_bucket.bucket_1' cannot be created directly. Module(s) 'terraform-aws-modules/s3-bucket/aws' must be used instead"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_s3_bucket.bucket_1",
 		"type": "aws_s3_bucket",
 		"change": {"actions": ["update"]},
@@ -19,8 +22,8 @@ test_deny_update_of_controlled_resource_type {
 }
 
 # Test case for allowing deletion of controlled resource type.
-test_allow_deletion_of_controlled_resource_type {
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_deletion_of_controlled_resource_type if {
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_s3_bucket.bucket_1",
 		"type": "aws_s3_bucket",
 		"change": {"actions": ["delete"]},
@@ -28,8 +31,8 @@ test_allow_deletion_of_controlled_resource_type {
 }
 
 # Test case for allowing creation of uncontrolled resource type.
-test_allow_creation_of_uncontrolled_resource_type {
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_creation_of_uncontrolled_resource_type if {
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_ecs_cluster.one",
 		"type": "aws_ecs_cluster",
 		"change": {"actions": ["create"]},

--- a/examples/plan/enforce-password-length.rego
+++ b/examples/plan/enforce-password-length.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This example plan policy prevents you from creating weak passwords, and warns
 # you when passwords are meh.
@@ -8,17 +9,17 @@ import future.keywords.in
 # You can read more about plan policies here:
 # https://docs.spacelift.io/concepts/policy/terraform-plan-policy
 
-deny[sprintf("We require that passwords have at least 16 characters (%s)", [resource.address])] {
+deny contains sprintf("We require that passwords have at least 16 characters (%s)", [resource.address]) if {
 	resource := new_password[_]
 	resource.change.after.length < 16
 }
 
-warn[sprintf("We advise that passwords have at least 20 characters (%s)", [resource.address])] {
+warn contains sprintf("We advise that passwords have at least 20 characters (%s)", [resource.address]) if {
 	resource := new_password[_]
 	resource.change.after.length < 20
 }
 
-new_password[resource] {
+new_password contains resource if {
 	resource := input.terraform.resource_changes[_]
 	"create" in resource.change.actions
 	resource.type == "random_password"

--- a/examples/plan/enforce-password-length_test.rego
+++ b/examples/plan/enforce-password-length_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying creation of a password with less than 16 characters.
-test_deny_creation_of_password_with_less_than_16_characters {
-	deny["We require that passwords have at least 16 characters (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
+test_deny_creation_of_password_with_less_than_16_characters if {
+	spacelift.deny["We require that passwords have at least 16 characters (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {
@@ -13,8 +16,8 @@ test_deny_creation_of_password_with_less_than_16_characters {
 }
 
 # Test case for warning creation of a password between 16 and 20 characters.
-test_warn_creation_of_password_between_16_and_20_characters {
-	warn["We advise that passwords have at least 20 characters (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
+test_warn_creation_of_password_between_16_and_20_characters if {
+	spacelift.warn["We advise that passwords have at least 20 characters (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {
@@ -25,8 +28,8 @@ test_warn_creation_of_password_between_16_and_20_characters {
 }
 
 # Test case for allowing creation of a password longer than 20 characters.
-test_allow_creation_of_password_longer_than_20_characters {
-	count(warn) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_creation_of_password_longer_than_20_characters if {
+	count(spacelift.warn) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {

--- a/examples/plan/enforce-sqlinstance-network.rego
+++ b/examples/plan/enforce-sqlinstance-network.rego
@@ -1,7 +1,10 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Deny changes that expose Cloud SQL instance to 0.0.0.0/0
-deny[msg] {
+deny contains msg if {
 	change := input.terraform.resource_changes[_]
 	change.type == "google_sql_database_instance"
 	valid_action(change.change.actions)
@@ -14,13 +17,13 @@ deny[msg] {
 }
 
 # Helper rule to check for valid actions
-valid_action(actions) {
+valid_action(actions) if {
 	action := actions[_]
 	action == "update"
 }
 
 # Helper rule to check for create action
-valid_action(actions) {
+valid_action(actions) if {
 	action := actions[_]
 	action == "create"
 }

--- a/examples/plan/enforce-sqlinstance-network_test.rego
+++ b/examples/plan/enforce-sqlinstance-network_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test allowing a valid Cloud SQL instance configuration
-test_allow_valid_cloud_sql_instance {
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_valid_cloud_sql_instance if {
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"type": "google_sql_database_instance",
 		"change": {
 			"actions": ["create"],
@@ -12,8 +15,8 @@ test_allow_valid_cloud_sql_instance {
 }
 
 # Test denying a Cloud SQL instance open to 0.0.0.0/0
-test_deny_cloud_sql_instance_open_to_world {
-	deny with input as {"terraform": {"resource_changes": [{
+test_deny_cloud_sql_instance_open_to_world if {
+	spacelift.deny with input as {"terraform": {"resource_changes": [{
 		"type": "google_sql_database_instance",
 		"change": {
 			"actions": ["create"],
@@ -23,8 +26,8 @@ test_deny_cloud_sql_instance_open_to_world {
 }
 
 # Test non-applicability for a non-Cloud SQL resource
-test_allow_non_cloud_sql_resource {
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_non_cloud_sql_resource if {
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"type": "google_compute_instance",
 		"change": {
 			"actions": ["create"],

--- a/examples/plan/enforce-tags-on-resources.rego
+++ b/examples/plan/enforce-tags-on-resources.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This example plan policy enforces specific tags are present on your resources
 #
 # You can read more about plan policies here:
@@ -7,7 +10,7 @@ package spacelift
 
 required_tags := {"Name", "env", "owner"}
 
-deny[sprintf("resource %q does not have all suggested tags (%s)", [resource.address, concat(", ", missing_tags)])] {
+deny contains sprintf("resource %q does not have all suggested tags (%s)", [resource.address, concat(", ", missing_tags)]) if {
 	resource := input.terraform.resource_changes[_]
 	tags := resource.change.after.tags_all
 

--- a/examples/plan/enforce-tags-on-resources_test.rego
+++ b/examples/plan/enforce-tags-on-resources_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying creation of a resource with no enforced tags.
-test_deny_creation_of_resource_with_no_enforced_tags {
-	deny["resource \"random_password.password_1\" does not have all suggested tags (Name, env, owner)"] with input as {"terraform": {"resource_changes": [{
+test_deny_creation_of_resource_with_no_enforced_tags if {
+	spacelift.deny["resource \"random_password.password_1\" does not have all suggested tags (Name, env, owner)"] with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {
@@ -13,8 +16,8 @@ test_deny_creation_of_resource_with_no_enforced_tags {
 }
 
 # Test case for allowing creation of a resource with enforced tags.
-test_allow_creation_of_resource_with_enforced_tags {
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_creation_of_resource_with_enforced_tags if {
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {
@@ -29,8 +32,8 @@ test_allow_creation_of_resource_with_enforced_tags {
 }
 
 # Test case for allowing creation of a resource with partial enforced tags.
-test_allow_creation_of_resource_with_partial_enforced_tags {
-	deny["resource \"random_password.password_1\" does not have all suggested tags (env)"] with input as {"terraform": {"resource_changes": [{
+test_allow_creation_of_resource_with_partial_enforced_tags if {
+	spacelift.deny["resource \"random_password.password_1\" does not have all suggested tags (env)"] with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {

--- a/examples/plan/enforce-terraform-version-list.rego
+++ b/examples/plan/enforce-terraform-version-list.rego
@@ -16,7 +16,7 @@ deny contains sprintf("Not allowed to use Terraform version %s. Please consider 
 	terraform_version := input.terraform.terraform_version
 
 	# Check if the Terraform version is one of those defined in the notallowed_versions list
-	notallowed_versions[_] = terraform_version
+	terraform_version in notallowed_versions
 }
 
 # The "warn" rule fires for any other Terraform version.
@@ -31,12 +31,12 @@ warn contains sprintf("You're using Terraform version %s, which isn't explicitly
 
 # Helper rule to check if a version is in the allowed_versions
 is_version_allowed(version) if {
-	allowed_versions[_] = version
+	version in allowed_versions
 }
 
 # Helper rule to check if a version is in the notallowed_versions
 is_version_notallowed(version) if {
-	notallowed_versions[_] = version
+	version in notallowed_versions
 }
 
 # Learn more about sampling policy evaluations here:

--- a/examples/plan/enforce-terraform-version-list.rego
+++ b/examples/plan/enforce-terraform-version-list.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Define a list of not allowed Terraform versions.
 notallowed_versions := ["1.4.1", "1.4.2", "1.4.3"]
 
@@ -8,7 +11,7 @@ allowed_versions := ["1.4.4", "1.4.5", "1.5.0"]
 
 # The "deny" rule fires when a blocked Terraform version is used.
 # The result is a formatted message with the blocked version.
-deny[sprintf("Not allowed to use Terraform version %s. Please consider using one of the following versions: %v", [terraform_version, allowed_versions])] {
+deny contains sprintf("Not allowed to use Terraform version %s. Please consider using one of the following versions: %v", [terraform_version, allowed_versions]) if {
 	# Extract the Terraform version from the runtime configuration
 	terraform_version := input.terraform.terraform_version
 
@@ -17,7 +20,7 @@ deny[sprintf("Not allowed to use Terraform version %s. Please consider using one
 }
 
 # The "warn" rule fires for any other Terraform version.
-warn[sprintf("You're using Terraform version %s, which isn't explicitly allowed or denied. Consider using one of the allowed versions: %v", [terraform_version, allowed_versions])] {
+warn contains sprintf("You're using Terraform version %s, which isn't explicitly allowed or denied. Consider using one of the allowed versions: %v", [terraform_version, allowed_versions]) if {
 	# Extract the Terraform version from the runtime configuration
 	terraform_version := input.terraform.terraform_version
 
@@ -27,12 +30,12 @@ warn[sprintf("You're using Terraform version %s, which isn't explicitly allowed 
 }
 
 # Helper rule to check if a version is in the allowed_versions
-is_version_allowed(version) {
+is_version_allowed(version) if {
 	allowed_versions[_] = version
 }
 
 # Helper rule to check if a version is in the notallowed_versions
-is_version_notallowed(version) {
+is_version_notallowed(version) if {
 	notallowed_versions[_] = version
 }
 

--- a/examples/plan/enforce-terraform-version-list_test.rego
+++ b/examples/plan/enforce-terraform-version-list_test.rego
@@ -1,52 +1,55 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test for denied versions
-test_deny_1_4_1 {
+test_deny_1_4_1 if {
 	inp := {"terraform": {"terraform_version": "1.4.1"}}
-	count(deny) == 1 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 1 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_deny_1_4_2 {
+test_deny_1_4_2 if {
 	inp := {"terraform": {"terraform_version": "1.4.2"}}
-	count(deny) == 1 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 1 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_deny_1_4_3 {
+test_deny_1_4_3 if {
 	inp := {"terraform": {"terraform_version": "1.4.3"}}
-	count(deny) == 1 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 1 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test for allowed versions (should not warn or deny)
-test_allow_1_4_4 {
+test_allow_1_4_4 if {
 	inp := {"terraform": {"terraform_version": "1.4.4"}}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_allow_1_4_5 {
+test_allow_1_4_5 if {
 	inp := {"terraform": {"terraform_version": "1.4.5"}}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
-test_allow_1_5_0 {
+test_allow_1_5_0 if {
 	inp := {"terraform": {"terraform_version": "1.5.0"}}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test for versions that should generate a warning
-test_warn_1_4_0 {
+test_warn_1_4_0 if {
 	inp := {"terraform": {"terraform_version": "1.4.0"}}
-	count(deny) == 0 with input as inp
-	count(warn) == 1 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 1 with input as inp
 }
 
-test_warn_1_5_1 {
+test_warn_1_5_1 if {
 	inp := {"terraform": {"terraform_version": "1.5.1"}}
-	count(deny) == 0 with input as inp
-	count(warn) == 1 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 1 with input as inp
 }

--- a/examples/plan/ensure-resource-creation-before-deletion.rego
+++ b/examples/plan/ensure-resource-creation-before-deletion.rego
@@ -1,10 +1,13 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy ensures that the listed resource types will be created before being deleted to avoid an incident
 
 always_create_first := {"aws_batch_compute_environment"}
 
-deny[sprintf(message, [resource.address])] {
+deny contains sprintf(message, [resource.address]) if {
 	message := "Always create before deleting (%s)"
 	resource := input.terraform.resource_changes[_]
 

--- a/examples/plan/ensure-resource-creation-before-deletion_test.rego
+++ b/examples/plan/ensure-resource-creation-before-deletion_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying resources with a certain resource type that will be deleted before created.
-test_deny_non_create_before_destroy_lifecycle {
-	deny["Always create before deleting (aws_batch_compute_environment.test_1)"] with input as {"terraform": {"resource_changes": [{
+test_deny_non_create_before_destroy_lifecycle if {
+	spacelift.deny["Always create before deleting (aws_batch_compute_environment.test_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "aws_batch_compute_environment.test_1",
 		"type": "aws_batch_compute_environment",
 		"change": {"actions": ["delete", "create"]},
@@ -10,8 +13,8 @@ test_deny_non_create_before_destroy_lifecycle {
 }
 
 # Test case for allowing resources with a certain resource type that will be created before deleted.
-test_allow_create_before_destroy_lifecycle {
-	count(deny) == 0 with input as {"terraform": {"resource_changes": [{
+test_allow_create_before_destroy_lifecycle if {
+	count(spacelift.deny) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_batch_compute_environment.test_1",
 		"type": "aws_batch_compute_environment",
 		"change": {"actions": ["create", "delete"]},

--- a/examples/plan/infracost-monthly-cost-restriction.rego
+++ b/examples/plan/infracost-monthly-cost-restriction.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This example plan policy demonstrates using data from infracost to
 # ensure that resources can't be created if their mostly cost is greater than
 # a specific threshold while displaying a warning if their cost is above
@@ -9,14 +12,14 @@ package spacelift
 # https://docs.spacelift.io/concepts/policy/terraform-plan-policy
 
 # Prevent any changes that will cause the monthly cost to go above a certain threshold
-deny[sprintf("monthly cost greater than $%d ($%.2f)", [threshold, monthly_cost])] {
+deny contains sprintf("monthly cost greater than $%d ($%.2f)", [threshold, monthly_cost]) if {
 	threshold := 100
 	monthly_cost := to_number(input.third_party_metadata.custom.infracost.projects[0].breakdown.totalMonthlyCost)
 	monthly_cost > threshold
 }
 
 # Warn if the monthly costs increase more than a certain percentage
-warn[sprintf("monthly cost increase greater than %d%% (%.2f%%)", [threshold, percentage_increase])] {
+warn contains sprintf("monthly cost increase greater than %d%% (%.2f%%)", [threshold, percentage_increase]) if {
 	threshold := 5
 	previous_cost := to_number(input.third_party_metadata.custom.infracost.projects[0].pastBreakdown.totalMonthlyCost)
 	previous_cost > 0

--- a/examples/plan/infracost-monthly-cost-restriction_test.rego
+++ b/examples/plan/infracost-monthly-cost-restriction_test.rego
@@ -1,21 +1,24 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying when monthly estimated cost exceeds a certain threshold.
-test_deny_infracost_monthly_cost_exceeds_threshold {
-	deny["monthly cost greater than $100 ($101.00)"] with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 101.00}}]}}}}
+test_deny_infracost_monthly_cost_exceeds_threshold if {
+	spacelift.deny["monthly cost greater than $100 ($101.00)"] with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 101.00}}]}}}}
 }
 
 # Test case for not denying when monthly estimated cost is below a certain threshold.
-test_not_deny_infracost_monthly_cost_is_below_threshold {
-	count(deny) == 0 with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 99.00}}]}}}}
+test_not_deny_infracost_monthly_cost_is_below_threshold if {
+	count(spacelift.deny) == 0 with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 99.00}}]}}}}
 }
 
 # Test case for warning when monthly costs increased more than a certain percentage.
-test_warn_infracost_monthly_cost_increase_percentage_exceeds_threshold {
-	warn["monthly cost increase greater than 5% (395.05%)"] with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 5.00}, "pastBreakdown": {"totalMonthlyCost": 1.01}}]}}}}
+test_warn_infracost_monthly_cost_increase_percentage_exceeds_threshold if {
+	spacelift.warn["monthly cost increase greater than 5% (395.05%)"] with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 5.00}, "pastBreakdown": {"totalMonthlyCost": 1.01}}]}}}}
 }
 
 # Test case for not warning when monthly costs increased less than a certain percentage.
-test_not_warn_infracost_monthly_cost_increase_percentage_does_not_exceed_threshold {
-	count(warn) == 0 with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 40.10}, "pastBreakdown": {"totalMonthlyCost": 40.00}}]}}}}
+test_not_warn_infracost_monthly_cost_increase_percentage_does_not_exceed_threshold if {
+	count(spacelift.warn) == 0 with input as {"third_party_metadata": {"custom": {"infracost": {"projects": [{"breakdown": {"totalMonthlyCost": 40.10}, "pastBreakdown": {"totalMonthlyCost": 40.00}}]}}}}
 }

--- a/examples/plan/kics-severity-counter.rego
+++ b/examples/plan/kics-severity-counter.rego
@@ -1,16 +1,19 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy will give you a warning with all the info, low and medium issues number
 # and deny any run that has a high severity issue.
 
-warn[sprintf(message, [info, low, medium])] {
+warn contains sprintf(message, [info, low, medium]) if {
 	message := "You have: %d info issues, %d low issues, %d medium issues"
 	info := input.third_party_metadata.custom.kics.severity_counters.INFO
 	low := input.third_party_metadata.custom.kics.severity_counters.LOW
 	medium := input.third_party_metadata.custom.kics.severity_counters.MEDIUM
 }
 
-deny[sprintf(message, [results, p])] {
+deny contains sprintf(message, [results, p]) if {
 	message := "The number of violated policies %d is higher than the threshold %d"
 	results := input.third_party_metadata.custom.kics.severity_counters.HIGH
 	p := 0

--- a/examples/plan/kics-severity-counter_test.rego
+++ b/examples/plan/kics-severity-counter_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for warning with severity counters.
-test_warn_severity_counters {
-	warn["You have: 1 info issues, 2 low issues, 3 medium issues"] with input as {"third_party_metadata": {"custom": {"kics": {"severity_counters": {
+test_warn_severity_counters if {
+	spacelift.warn["You have: 1 info issues, 2 low issues, 3 medium issues"] with input as {"third_party_metadata": {"custom": {"kics": {"severity_counters": {
 		"INFO": 1,
 		"LOW": 2,
 		"MEDIUM": 3,
@@ -11,8 +14,8 @@ test_warn_severity_counters {
 }
 
 # Test case for denying with high severity issues.
-test_deny_for_high_severity_issue {
-	deny["The number of violated policies 10 is higher than the threshold 0"] with input as {"third_party_metadata": {"custom": {"kics": {"severity_counters": {
+test_deny_for_high_severity_issue if {
+	spacelift.deny["The number of violated policies 10 is higher than the threshold 0"] with input as {"third_party_metadata": {"custom": {"kics": {"severity_counters": {
 		"INFO": 1,
 		"LOW": 2,
 		"MEDIUM": 3,

--- a/examples/plan/mandatory-and-acceptable-labels-gcp.rego
+++ b/examples/plan/mandatory-and-acceptable-labels-gcp.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 mandatory_labels := {"mandatory1", "mandatory2"}
 

--- a/examples/plan/mandatory-and-acceptable-labels-gcp_test.rego
+++ b/examples/plan/mandatory-and-acceptable-labels-gcp_test.rego
@@ -1,9 +1,8 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test for missing mandatory labels
 test_deny_for_missing_mandatory_labels if {

--- a/examples/plan/mandatory-and-acceptable-labels-stack.rego
+++ b/examples/plan/mandatory-and-acceptable-labels-stack.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # METADATA
 # description: Making sure mandatory labels are present and only allowing certain labels

--- a/examples/plan/mandatory-and-acceptable-labels-stack_test.rego
+++ b/examples/plan/mandatory-and-acceptable-labels-stack_test.rego
@@ -1,9 +1,8 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test for missing or empty labels
 test_deny_with_no_labels if {

--- a/examples/plan/require-human-review-for-drift-detection-reconciliation.rego
+++ b/examples/plan/require-human-review-for-drift-detection-reconciliation.rego
@@ -1,5 +1,8 @@
 package spacelift
 
-warn["Drift reconciliation requires manual approval"] {
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
+warn contains "Drift reconciliation requires manual approval" if {
 	input.spacelift.run.drift_detection
 }

--- a/examples/plan/require-human-review-for-drift-detection-reconciliation_test.rego
+++ b/examples/plan/require-human-review-for-drift-detection-reconciliation_test.rego
@@ -1,16 +1,19 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for drift reconciliation runs requiring manual approval
-test_warn_drift_reconciliation_runs_requires_manual_approval {
-	warn["Drift reconciliation requires manual approval"] with input as {"spacelift": {"run": {
+test_warn_drift_reconciliation_runs_requires_manual_approval if {
+	spacelift.warn["Drift reconciliation requires manual approval"] with input as {"spacelift": {"run": {
 		"drift_detection": true,
 		"type": "TRACKED",
 	}}}
 }
 
 # Test case for non drift reconciliation requiring manual approval
-test_non_drift_reconciliation_runs_require_no_manual_approval {
-	count(warn) == 0 with input as {"spacelift": {"run": {
+test_non_drift_reconciliation_runs_require_no_manual_approval if {
+	count(spacelift.warn) == 0 with input as {"spacelift": {"run": {
 		"drift_detection": false,
 		"type": "TRACKED",
 	}}}

--- a/examples/plan/require-human-review-for-unreachable-ansible-hosts.rego
+++ b/examples/plan/require-human-review-for-unreachable-ansible-hosts.rego
@@ -1,9 +1,12 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy emits warning when some of the Ansbile hosts were unreachable
 # so that a human review is required.
 
-warn["Some hosts were unreachable"] {
+warn contains "Some hosts were unreachable" if {
 	input.ansible.dark != {}
 }
 

--- a/examples/plan/require-human-review-for-unreachable-ansible-hosts_test.rego
+++ b/examples/plan/require-human-review-for-unreachable-ansible-hosts_test.rego
@@ -1,13 +1,16 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for warning when some ansible hosts were unreachable.
-test_warn_ansible_host_are_unreachable {
-	warn["Some hosts were unreachable"] with input as {"ansible": {"dark": {"test": true}}}
+test_warn_ansible_host_are_unreachable if {
+	spacelift.warn["Some hosts were unreachable"] with input as {"ansible": {"dark": {"test": true}}}
 }
 
 #
 
 # Test case for no warning when all ansible hosts were reachable.
-test_no_warn_all_ansible_host_are_reachable {
-	count(warn) == 0 with input as {"ansible": {"dark": {}}}
+test_no_warn_all_ansible_host_are_reachable if {
+	count(spacelift.warn) == 0 with input as {"ansible": {"dark": {}}}
 }

--- a/examples/plan/require-human-review-for-update-deletion.rego
+++ b/examples/plan/require-human-review-for-update-deletion.rego
@@ -1,10 +1,13 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Adding resources may ultimately cost a lot of money but it's generally pretty safe from an operational perspective.
 # Let's use a `warn` rule to allow changes with only added resources to get automatically applied,
 # and require all others to get a human review.
 
-warn[sprintf(message, [action, resource.address])] {
+warn contains sprintf(message, [action, resource.address]) if {
 	message := "action '%s' requires human review (%s)"
 	review := {"update", "delete"}
 

--- a/examples/plan/require-human-review-for-update-deletion_test.rego
+++ b/examples/plan/require-human-review-for-update-deletion_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for no warning on creation.
-test_warn_on_creation {
-	count(warn) == 0 with input as {"terraform": {"resource_changes": [{
+test_warn_on_creation if {
+	count(spacelift.warn) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {"actions": ["create"]},
@@ -10,8 +13,8 @@ test_warn_on_creation {
 }
 
 # Test case for warning on update.
-test_warn_on_update {
-	warn["action 'update' requires human review (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
+test_warn_on_update if {
+	spacelift.warn["action 'update' requires human review (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {"actions": ["update"]},
@@ -19,8 +22,8 @@ test_warn_on_update {
 }
 
 # Test case for warning on delete.
-test_warn_on_deletion {
-	warn["action 'delete' requires human review (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
+test_warn_on_deletion if {
+	spacelift.warn["action 'delete' requires human review (random_password.password_1)"] with input as {"terraform": {"resource_changes": [{
 		"address": "random_password.password_1",
 		"type": "random_password",
 		"change": {"actions": ["delete"]},

--- a/examples/plan/require-reasonable-commit-size.rego
+++ b/examples/plan/require-reasonable-commit-size.rego
@@ -1,21 +1,24 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Massive changes make reviewers miserable. Let's automatically fail all changes that affect more than 50 resources.
 # Let's also allow them to be deployed with mandatory human review nevertheless.
 
 proposed := input.spacelift.run.type == "PROPOSED"
 
-deny[msg] {
+deny contains msg if {
 	proposed
 	msg := too_many_changes[_]
 }
 
-warn[msg] {
+warn contains msg if {
 	not proposed
 	msg := too_many_changes[_]
 }
 
-too_many_changes[msg] {
+too_many_changes contains msg if {
 	threshold := 50
 
 	res := input.terraform.resource_changes

--- a/examples/plan/require-reasonable-commit-size_test.rego
+++ b/examples/plan/require-reasonable-commit-size_test.rego
@@ -1,7 +1,10 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for denying proposed run with too many changes.
-test_deny_for_proposed_run_with_too_many_changes {
+test_deny_for_proposed_run_with_too_many_changes if {
 	inp := {
 		"spacelift": {"run": {"type": "PROPOSED"}},
 		"terraform": {"resource_changes": [
@@ -58,12 +61,12 @@ test_deny_for_proposed_run_with_too_many_changes {
 			{"change": {"actions": ["delete"]}},
 		]},
 	}
-	count(warn) == 0 with input as inp
-	deny["More than 50 changes (51)"] with input as inp
+	count(spacelift.warn) == 0 with input as inp
+	spacelift.deny["More than 50 changes (51)"] with input as inp
 }
 
 # Test case for denying tracked with too many changes.
-test_deny_for_tracked_run_with_too_many_changes {
+test_deny_for_tracked_run_with_too_many_changes if {
 	inp := {
 		"spacelift": {"run": {"type": "TRACKED"}},
 		"terraform": {"resource_changes": [
@@ -120,12 +123,12 @@ test_deny_for_tracked_run_with_too_many_changes {
 			{"change": {"actions": ["delete"]}},
 		]},
 	}
-	count(deny) == 0 with input as inp
-	warn["More than 50 changes (51)"] with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	spacelift.warn["More than 50 changes (51)"] with input as inp
 }
 
 # Test case if no-op changes are included.
-test_no_op_changes {
+test_no_op_changes if {
 	inp := {
 		"spacelift": {"run": {"type": "TRACKED"}},
 		"terraform": {"resource_changes": [
@@ -182,26 +185,26 @@ test_no_op_changes {
 			{"change": {"actions": ["delete"]}},
 		]},
 	}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test case tracked run for no warning for reasonable commit.
-test_no_warn_for_tracked_run_with_reasonable_commit {
+test_no_warn_for_tracked_run_with_reasonable_commit if {
 	inp := {
 		"spacelift": {"run": {"type": "TRACKED"}},
 		"terraform": {"resource_changes": [{"change": {"actions": ["delete"]}}]},
 	}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }
 
 # Test case tracked run for no denying for reasonable commit.
-test_no_deny_for_proposed_run_with_reasonable_commit {
+test_no_deny_for_proposed_run_with_reasonable_commit if {
 	inp := {
 		"spacelift": {"run": {"type": "PROPOSED"}},
 		"terraform": {"resource_changes": [{"change": {"actions": ["delete"]}}]},
 	}
-	count(deny) == 0 with input as inp
-	count(warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
 }

--- a/examples/plan/terrascan-violated-policies.rego
+++ b/examples/plan/terrascan-violated-policies.rego
@@ -1,14 +1,17 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy checks the number of violated terrascan policies
 # and shows a warning with the number of them, also, if the number of violated policies is greater than 2, it will deny the run.
 
-warn[sprintf(message, [results])] {
+warn contains sprintf(message, [results]) if {
 	message := "You have a couple of violated policies: %d"
 	results := input.third_party_metadata.custom.terrascan.results.scan_summary.violated_policies
 }
 
-deny[sprintf(message, [results, p])] {
+deny contains sprintf(message, [results, p]) if {
 	message := "The number of violated policies %d is higher than the threshold %d"
 	results := input.third_party_metadata.custom.terrascan.results.scan_summary.violated_policies
 	p := 2

--- a/examples/plan/terrascan-violated-policies_test.rego
+++ b/examples/plan/terrascan-violated-policies_test.rego
@@ -1,18 +1,21 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for warning when terrascan detected some violated policies, but the count is below the threshold.
-test_warn_violated_terrascan_policies_below_threshold {
-	warn["You have a couple of violated policies: 1"] with input as {"third_party_metadata": {"custom": {"terrascan": {"results": {"scan_summary": {"violated_policies": 1}}}}}}
+test_warn_violated_terrascan_policies_below_threshold if {
+	spacelift.warn["You have a couple of violated policies: 1"] with input as {"third_party_metadata": {"custom": {"terrascan": {"results": {"scan_summary": {"violated_policies": 1}}}}}}
 }
 
 # Test case for warning when terrascan detected no violated policies.
-test_no_warning_or_deny_when_there_are_no_violated_terrascan_policies {
+test_no_warning_or_deny_when_there_are_no_violated_terrascan_policies if {
 	inp := {"third_party_metadata": {"custom": {"terrascan": {"results": {"scan_summary": {}}}}}}
-	count(warn) == 0 with input as inp
-	count(deny) == 0 with input as inp
+	count(spacelift.warn) == 0 with input as inp
+	count(spacelift.deny) == 0 with input as inp
 }
 
 # Test case for denying when terrascan detected violated policies, the count has exceeded the threshold.
-test_deny_violated_terrascan_policies_exceeded_threshold {
-	deny["The number of violated policies 3 is higher than the threshold 2"] with input as {"third_party_metadata": {"custom": {"terrascan": {"results": {"scan_summary": {"violated_policies": 3}}}}}}
+test_deny_violated_terrascan_policies_exceeded_threshold if {
+	spacelift.deny["The number of violated policies 3 is higher than the threshold 2"] with input as {"third_party_metadata": {"custom": {"terrascan": {"results": {"scan_summary": {"violated_policies": 3}}}}}}
 }

--- a/examples/plan/tfsec-high-severity-issues.rego
+++ b/examples/plan/tfsec-high-severity-issues.rego
@@ -1,8 +1,11 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy checks how many high severity issues has tfsec found
 
-warn[sprintf(message, [p])] {
+warn contains sprintf(message, [p]) if {
 	message := "You have a couple of high serverity issues: %d"
 	results := input.third_party_metadata.custom.tfsec.results
 	p := count({result | result := results[_]; result.severity == "HIGH"})

--- a/examples/plan/tfsec-high-severity-issues_test.rego
+++ b/examples/plan/tfsec-high-severity-issues_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for warning when tfsec detected some issues, the count has exceeded the threshold.
-test_warning_when_there_are_some_issues_below_threshold {
-	warn["You have a couple of high serverity issues: 4"] with input as {"third_party_metadata": {"custom": {"tfsec": {"results": [
+test_warning_when_there_are_some_issues_below_threshold if {
+	spacelift.warn["You have a couple of high serverity issues: 4"] with input as {"third_party_metadata": {"custom": {"tfsec": {"results": [
 		{
 			"severity": "HIGH",
 			"test": 1,

--- a/examples/plan/trivy-high-severity-issues.rego
+++ b/examples/plan/trivy-high-severity-issues.rego
@@ -1,8 +1,11 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This policy returns warnings for every high severity issue trivy finds
 
-warn[sprintf("Warning due to high severity misconfiguration: %s", [title])] {
+warn contains sprintf("Warning due to high severity misconfiguration: %s", [title]) if {
 	misconf := input.third_party_metadata.custom.trivy.Results[_].Misconfigurations[_]
 	misconf.Severity == "HIGH"
 	misconf.Status == "FAIL"

--- a/examples/plan/trivy-high-severity-issues_test.rego
+++ b/examples/plan/trivy-high-severity-issues_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for warning when trivy encountered misconfingurations.
-test_high_severity_warnings_are_generated {
-	warn["Warning due to high severity misconfiguration: Instance with unencrypted block device."] with input as {"third_party_metadata": {"custom": {"trivy": {"Results": [
+test_high_severity_warnings_are_generated if {
+	spacelift.warn["Warning due to high severity misconfiguration: Instance with unencrypted block device."] with input as {"third_party_metadata": {"custom": {"trivy": {"Results": [
 		{"Misconfigurations": [
 			{
 				"Severity": "HIGH",
@@ -21,7 +24,7 @@ test_high_severity_warnings_are_generated {
 			"Title": "Instance does not require IMDS access to require a token",
 		}]},
 	]}}}}
-	warn["Warning due to high severity misconfiguration: Instance does not require IMDS access to require a token"] with input as {"third_party_metadata": {"custom": {"trivy": {"Results": [
+	spacelift.warn["Warning due to high severity misconfiguration: Instance does not require IMDS access to require a token"] with input as {"third_party_metadata": {"custom": {"trivy": {"Results": [
 		{"Misconfigurations": [
 			{
 				"Severity": "HIGH",

--- a/examples/plan/trusted-engineers-bypass-review.rego
+++ b/examples/plan/trusted-engineers-bypass-review.rego
@@ -1,11 +1,14 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # Sometimes there are folks who really know what they're doing and changes they introduce can get deployed automatically,
 # especially if they already went through code review.
 #
 # This policy allows commits from allowed individuals to be deployed automatically (assumes Stack is set to autodeploy).
 
-warn[sprintf(message, [author])] {
+warn contains sprintf(message, [author]) if {
 	message := "%s is not on the allow list - human review required"
 	author := input.spacelift.commit.author
 	allowed := {"alice", "bob", "charlie"}

--- a/examples/plan/trusted-engineers-bypass-review_test.rego
+++ b/examples/plan/trusted-engineers-bypass-review_test.rego
@@ -1,11 +1,14 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test case for not warning for trusted engineers
-test_no_warn_for_trusted_engineers {
-	count(warn) == 0 with input as {"spacelift": {"commit": {"author": "alice"}}}
+test_no_warn_for_trusted_engineers if {
+	count(spacelift.warn) == 0 with input as {"spacelift": {"commit": {"author": "alice"}}}
 }
 
 # Test case for warning for untrusted engineers
-test_warn_for_untrusted_engineers {
-	warn["michiel is not on the allow list - human review required"] with input as {"spacelift": {"commit": {"author": "michiel"}}}
+test_warn_for_untrusted_engineers if {
+	spacelift.warn["michiel is not on the allow list - human review required"] with input as {"spacelift": {"commit": {"author": "michiel"}}}
 }

--- a/examples/plan/warn-on-change-sensitive-resources.rego
+++ b/examples/plan/warn-on-change-sensitive-resources.rego
@@ -1,6 +1,9 @@
 package spacelift
 
-warn[sprintf(message, [resource.address, action])] {
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
+warn contains sprintf(message, [resource.address, action]) if {
 	message := "resource: %s action %s requires human review"
 
 	review := {"delete", "update"} # Review actions include both "update" and "delete"

--- a/examples/plan/warn-on-change-sensitive-resources_test.rego
+++ b/examples/plan/warn-on-change-sensitive-resources_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test for `aws_iam_user` resource being updated
-test_warn_update_iam_user {
-	count(warn) == 1 with input as {"terraform": {"resource_changes": [{
+test_warn_update_iam_user if {
+	count(spacelift.warn) == 1 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_user.example",
 		"type": "aws_iam_user",
 		"change": {"actions": ["update"]},
@@ -10,8 +13,8 @@ test_warn_update_iam_user {
 }
 
 # Test for `aws_iam_role` resource being deleted
-test_warn_delete_iam_role {
-	count(warn) == 1 with input as {"terraform": {"resource_changes": [{
+test_warn_delete_iam_role if {
+	count(spacelift.warn) == 1 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_role.example",
 		"type": "aws_iam_role",
 		"change": {"actions": ["delete"]},
@@ -19,8 +22,8 @@ test_warn_delete_iam_role {
 }
 
 # Test for non-sensitive resource being updated
-test_no_warn_update_ec2_instance {
-	count(warn) == 0 with input as {"terraform": {"resource_changes": [{
+test_no_warn_update_ec2_instance if {
+	count(spacelift.warn) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_instance.example",
 		"type": "aws_instance",
 		"change": {"actions": ["update"]},
@@ -28,8 +31,8 @@ test_no_warn_update_ec2_instance {
 }
 
 # Test for sensitive resource being created (shouldn't trigger a warning)
-test_no_warn_create_iam_policy {
-	count(warn) == 0 with input as {"terraform": {"resource_changes": [{
+test_no_warn_create_iam_policy if {
+	count(spacelift.warn) == 0 with input as {"terraform": {"resource_changes": [{
 		"address": "aws_iam_policy.example",
 		"type": "aws_iam_policy",
 		"change": {"actions": ["create"]},
@@ -37,8 +40,8 @@ test_no_warn_create_iam_policy {
 }
 
 # Test for multiple sensitive resources being updated and deleted (should trigger multiple warnings)
-test_multiple_warnings {
-	count(warn) == 2 with input as {"terraform": {"resource_changes": [
+test_multiple_warnings if {
+	count(spacelift.warn) == 2 with input as {"terraform": {"resource_changes": [
 		{
 			"address": "aws_iam_policy.example",
 			"type": "aws_iam_policy",

--- a/examples/push/allow-forks.rego
+++ b/examples/push/allow-forks.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.if
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # By default, runs are not triggered when a forked repository opens a pull request against your repository.
 # This is because of a security concern: if let's say your infrastructure is open source, someone forks it,

--- a/examples/push/allow-forks_test.rego
+++ b/examples/push/allow-forks_test.rego
@@ -1,15 +1,17 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
 
 # Test allowing fork from a trusted user
-test_allow_fork_trusted_user {
-	input := {"pull_request": {"head_owner": "johnwayne"}}
-	spacelift.allow_fork with input as input
+test_allow_fork_trusted_user if {
+	test_input := {"pull_request": {"head_owner": "johnwayne"}}
+	spacelift.allow_fork with input as test_input
 }
 
 # Test not allowing fork from an untrusted user
-test_not_allow_fork_untrusted_user {
-	input := {"pull_request": {"head_owner": "randomuser"}}
-	not spacelift.allow_fork with input as input
+test_not_allow_fork_untrusted_user if {
+	test_input := {"pull_request": {"head_owner": "randomuser"}}
+	not spacelift.allow_fork with input as test_input
 }

--- a/examples/push/cancel-in-progress-runs.rego
+++ b/examples/push/cancel-in-progress-runs.rego
@@ -1,10 +1,13 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # The push policy can be used to have the new run pre-empt any runs that are
 # currently in progress. The input document includes the in_progress key, which
 # contains an array of runs that are currently either still queued or are awaiting
 # human confirmation. You can use it in conjunction with the cancel rule like this:
-cancel[run.id] {
+cancel contains run.id if {
 	run := input.in_progress[_]
 	run.type == "PROPOSED"
 	run.state == "QUEUED"

--- a/examples/push/cancel-in-progress-runs_test.rego
+++ b/examples/push/cancel-in-progress-runs_test.rego
@@ -1,7 +1,10 @@
-package spacelift
+package spacelift_test
 
-test_cancel_runs_allowed {
-	cancel.test with input as {
+import data.spacelift
+import rego.v1
+
+test_cancel_runs_allowed if {
+	spacelift.cancel.test with input as {
 		"pull_request": {"head": {"branch": "main"}},
 		"in_progress": [{
 			"id": "test",
@@ -12,8 +15,8 @@ test_cancel_runs_allowed {
 	}
 }
 
-test_cancel_runs_denied {
-	not cancel.test with input as {
+test_cancel_runs_denied if {
+	not spacelift.cancel.test with input as {
 		"pull_request": {"head": {"branch": "feature/example"}},
 		"in_progress": [{
 			"id": "test",

--- a/examples/push/create-proposed-run-from-env-pr-labels.rego
+++ b/examples/push/create-proposed-run-from-env-pr-labels.rego
@@ -1,7 +1,7 @@
 package spacelift
 
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This example Git push policy will create proposed runs when it detects
 # a pull request label that starts with env:

--- a/examples/push/create-proposed-run-from-env-pr-labels_test.rego
+++ b/examples/push/create-proposed-run-from-env-pr-labels_test.rego
@@ -1,13 +1,14 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.if
 
 # Test proposing runs for matching env: prefixed labels
 test_propose_for_matching_env_labels if {
-	input := {
+	test_input := {
 		"stack": {"labels": ["env:production", "env:staging"]},
 		"pull_request": {"labels": ["env:production"]},
 	}
-	spacelift.propose with input as input
+	spacelift.propose with input as test_input
 }

--- a/examples/push/deploy-with-git-tag.rego
+++ b/examples/push/deploy-with-git-tag.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.if
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy deploys from a newly created git tag rather than from a branch
 

--- a/examples/push/deploy-with-git-tag_test.rego
+++ b/examples/push/deploy-with-git-tag_test.rego
@@ -1,26 +1,27 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.if
 
 test_track_with_valid_semver_tag if {
-	input := {"push": {"tag": "1.0.0"}}
-	spacelift.track with input as input
+	test_input := {"push": {"tag": "1.0.0"}}
+	spacelift.track with input as test_input
 }
 
 test_not_track_with_non_semver_tag if {
-	input := {"push": {"tag": "v1"}}
-	not spacelift.track with input as input
+	test_input := {"push": {"tag": "v1"}}
+	not spacelift.track with input as test_input
 }
 
 # Test for proposing changes on non-matching branch push
 test_propose_on_non_matching_branch if {
-	input := {
+	test_input := {
 		"push": {
 			"branch": "feature",
 			"tag": "",
 		},
 		"stack": {"branch": "main"},
 	}
-	spacelift.propose with input as input
+	spacelift.propose with input as test_input
 }

--- a/examples/push/deploy-with-pr-label.rego
+++ b/examples/push/deploy-with-pr-label.rego
@@ -1,7 +1,7 @@
 package spacelift
 
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy responds to a particular PR label ("deploy") to automatically deploy changes
 

--- a/examples/push/deploy-with-pr-label_test.rego
+++ b/examples/push/deploy-with-pr-label_test.rego
@@ -1,16 +1,17 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.if
 
 # Test tracking when PR is correctly labeled "deploy"
 test_track_with_deploy_label if {
-	input := {"pull_request": {"labels": ["deploy"]}}
-	spacelift.track with input as input
+	test_input := {"pull_request": {"labels": ["deploy"]}}
+	spacelift.track with input as test_input
 }
 
 # Test not tracking when PR does not have "deploy" label
 test_not_track_without_deploy_label if {
-	input := {"pull_request": {"labels": ["not-deploy"]}}
-	not spacelift.track with input as input
+	test_input := {"pull_request": {"labels": ["not-deploy"]}}
+	not spacelift.track with input as test_input
 }

--- a/examples/push/ignore-changes-outside-root.rego
+++ b/examples/push/ignore-changes-outside-root.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This example Git push policy ignores all changes that are outside a project's
 # root. Other than that, it follows the defaults - pushes to the tracked branch
 # trigger tracked runs, pushes to all other branches trigger proposed runs, tag
@@ -8,27 +11,27 @@ package spacelift
 # You can read more about push policies here:
 # https://docs.spacelift.io/concepts/policy/git-push-policy
 
-track {
+track if {
 	affected
 	input.push.branch == input.stack.branch
 }
 
-propose {
+propose if {
 	affected
 }
 
-ignore {
+ignore if {
 	not affected
 }
 
-ignore {
+ignore if {
 	input.push.tag != ""
 }
 
 # Here's a definition of an affected file - its path must both:
 # a) start with the Stack's project root, and;
 # b) end with ".tf", indicating that it's a Terraform source file;
-affected {
+affected if {
 	filepath := input.push.affected_files[_]
 
 	startswith(filepath, input.stack.project_root)

--- a/examples/push/ignore-changes-outside-root_test.rego
+++ b/examples/push/ignore-changes-outside-root_test.rego
@@ -1,52 +1,55 @@
-package spacelift
+package spacelift_test
 
-test_affected_no_files {
-	not affected with input as {
+import data.spacelift
+import rego.v1
+
+test_affected_no_files if {
+	not spacelift.affected with input as {
 		"stack": {"project_root": ""},
 		"push": {"affected_files": []},
 	}
 }
 
-test_affected_tf_files {
-	affected with input as {
+test_affected_tf_files if {
+	spacelift.affected with input as {
 		"stack": {"project_root": ""},
 		"push": {"affected_files": ["main.tf", "stacks.tf"]},
 	}
 }
 
-test_affected_no_tf_files {
-	not affected with input as {
+test_affected_no_tf_files if {
+	not spacelift.affected with input as {
 		"stack": {"project_root": ""},
 		"push": {"affected_files": ["README", "myicon.png"]},
 	}
 }
 
-test_affected_outside_project_root {
-	not affected with input as {
+test_affected_outside_project_root if {
+	not spacelift.affected with input as {
 		"stack": {"project_root": "stacks/my-stack"},
 		"push": {"affected_files": ["stacks/another-stack/main.tf"]},
 	}
 }
 
-test_ignore_affected {
-	ignore with affected as false
+test_ignore_affected if {
+	spacelift.ignore with spacelift.affected as false
 }
 
-test_ignore_not_affected {
-	not ignore with affected as true
+test_ignore_not_affected if {
+	not spacelift.ignore with spacelift.affected as true
 }
 
-test_ignore_tag {
-	ignore with input as {"push": {"tag": "v1.0.0"}}
-		with affected as true
+test_ignore_tag if {
+	spacelift.ignore with input as {"push": {"tag": "v1.0.0"}}
+		with spacelift.affected as true
 }
 
-test_propose_affected {
-	propose with affected as true
+test_propose_affected if {
+	spacelift.propose with spacelift.affected as true
 }
 
-test_propose_not_affected {
-	not propose with affected as false
+test_propose_not_affected if {
+	not spacelift.propose with spacelift.affected as false
 }
 
 matching_branch_input := {
@@ -54,18 +57,18 @@ matching_branch_input := {
 	"stack": {"branch": "main"},
 }
 
-test_track_affected {
-	track with input as matching_branch_input with affected as true
+test_track_affected if {
+	spacelift.track with input as matching_branch_input with spacelift.affected as true
 }
 
-test_track_not_affected {
-	not track with input as matching_branch_input with affected as false
+test_track_not_affected if {
+	not spacelift.track with input as matching_branch_input with spacelift.affected as false
 }
 
-test_track_not_stack_branch {
-	not track with input as {
+test_track_not_stack_branch if {
+	not spacelift.track with input as {
 		"push": {"branch": "my-feature"},
 		"stack": {"branch": "main"},
 	}
-		with affected as true
+		with spacelift.affected as true
 }

--- a/examples/push/lock-button-pauses-runs-by-pushes.rego
+++ b/examples/push/lock-button-pauses-runs-by-pushes.rego
@@ -1,24 +1,27 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # This is the default push policy with the condition that the locked button cannot be set by anyone.
 
-track {
+track if {
 	affected
 	input.push.branch == input.stack.branch
 	input.stack.locked_by == null
 }
 
-propose {
+propose if {
 	affected
 	input.push.branch != ""
 	input.stack.locked_by == null
 }
 
-ignore {
+ignore if {
 	input.push.branch == ""
 }
 
-affected {
+affected if {
 	strings.any_prefix_match(input.push.affected_files, input.stack.project_root)
 }
 

--- a/examples/push/lock-button-pauses-runs-by-pushes_test.rego
+++ b/examples/push/lock-button-pauses-runs-by-pushes_test.rego
@@ -1,4 +1,7 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Input for locked stack
 locked_stack_input := {
@@ -27,13 +30,13 @@ unlocked_stack_input := {
 }
 
 # Test that propose and track are true for unlocked stack
-test_propose_and_track_for_unlocked_stack {
-	propose with input as unlocked_stack_input
-	track with input as unlocked_stack_input
+test_propose_and_track_for_unlocked_stack if {
+	spacelift.propose with input as unlocked_stack_input
+	spacelift.track with input as unlocked_stack_input
 }
 
 # Test that propose and track are false for locked stack
-test_propose_and_track_for_locked_stack {
-	not propose with input as locked_stack_input
-	not track with input as locked_stack_input
+test_propose_and_track_for_locked_stack if {
+	not spacelift.propose with input as locked_stack_input
+	not spacelift.track with input as locked_stack_input
 }

--- a/examples/push/pr-comment-driven-actions.rego
+++ b/examples/push/pr-comment-driven-actions.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.if
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy requires the following permissions on your VCS provider:
 # - Read access to `issues` repository permissions

--- a/examples/push/pr-comment-driven-actions_test.rego
+++ b/examples/push/pr-comment-driven-actions_test.rego
@@ -1,16 +1,17 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.if
 
 # Test that a track action is triggered by a specific pull request comment
 test_track_for_specific_pr_comment if {
-	input := {
+	test_input := {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift deploy stack123",
 		},
 		"stack": {"id": "stack123"},
 	}
-	spacelift.track with input as input
+	spacelift.track with input as test_input
 }

--- a/examples/push/pr-comment-driven-user.rego
+++ b/examples/push/pr-comment-driven-user.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy requires the following permissions on your VCS provider:
 # - Read access to `issues` repository permissions
@@ -19,12 +20,12 @@ import future.keywords.in
 development_team := {"user1", "user2"}
 
 # This rule returns true if the user is in the development team
-is_development_team_member(user) {
+is_development_team_member(user) if {
 	user in development_team
 }
 
 # This rule creates a tracked run from a comment when it is a valid team member
-track {
+track if {
 	input.pull_request.action == "commented"
 	input.pull_request.comment == concat(" ", ["/spacelift", "deploy", input.stack.id])
 	is_development_team_member(input.pull_request.action_initiator)

--- a/examples/push/pr-comment-driven-user_test.rego
+++ b/examples/push/pr-comment-driven-user_test.rego
@@ -1,8 +1,11 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Test when everything is valid
-test_track_valid {
-	track with input as {
+test_track_valid if {
+	spacelift.track with input as {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift deploy testStack",
@@ -13,8 +16,8 @@ test_track_valid {
 }
 
 # Test for an invalid comment
-test_not_track_invalid_comment {
-	not track with input as {
+test_not_track_invalid_comment if {
+	not spacelift.track with input as {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift wrong deploy",
@@ -25,8 +28,8 @@ test_not_track_invalid_comment {
 }
 
 # Test for a non-team member
-test_not_track_non_team_member {
-	not track with input as {
+test_not_track_non_team_member if {
+	not spacelift.track with input as {
 		"pull_request": {
 			"action": "commented",
 			"comment": "/spacelift deploy testStack",

--- a/examples/push/prs-only.rego
+++ b/examples/push/prs-only.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.if
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy triggers proposed runs only if a PR exists,
 # and tracked runs only from PR merges.

--- a/examples/push/prs-only_test.rego
+++ b/examples/push/prs-only_test.rego
@@ -1,30 +1,31 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.if
 
 test_propose_for_pr if {
-	input := {
+	test_input := {
 		"pull_request": {"action": "commented"},
 		"push": {"branch": "feature"},
 		"stack": {"branch": "main"},
 	}
-	spacelift.propose with input as input
+	spacelift.propose with input as test_input
 }
 
 test_track_on_pr_merge if {
-	input := {
+	test_input := {
 		"pull_request": {"action": "merged"},
 		"push": {"branch": "main"},
 		"stack": {"branch": "main"},
 	}
-	spacelift.track with input as input
+	spacelift.track with input as test_input
 }
 
 test_ignore_non_pr_events if {
-	input := {
+	test_input := {
 		"push": {"branch": "feature"},
 		"stack": {"branch": "main"},
 	}
-	spacelift.ignore with input as input
+	spacelift.ignore with input as test_input
 }

--- a/examples/push/set-head-commit-no-trigger.rego
+++ b/examples/push/set-head-commit-no-trigger.rego
@@ -1,6 +1,7 @@
 package spacelift
 
-import future.keywords.if
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy sets the head commit but does not trigger a tracked run.
 # This is helpful when the tracked run gets triggered from elsewhere.

--- a/examples/push/set-head-commit-no-trigger_test.rego
+++ b/examples/push/set-head-commit-no-trigger_test.rego
@@ -1,24 +1,25 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.if
 
 # Test tracking on tracked branch without triggering a run
 test_track_on_tracked_branch if {
-	input := {
+	test_input := {
 		"push": {"branch": "main"},
 		"stack": {"branch": "main"},
 	}
-	spacelift.track with input as input
+	spacelift.track with input as test_input
 	spacelift.notrigger
 }
 
 # Test proposing on non-tracked branch
 test_propose_on_non_tracked_branch if {
-	input := {
+	test_input := {
 		"push": {"branch": "develop"},
 		"stack": {"branch": "main"},
 	}
-	spacelift.propose with input as input
+	spacelift.propose with input as test_input
 	spacelift.notrigger
 }

--- a/examples/push/tag-driven-tf-module-release-flow.rego
+++ b/examples/push/tag-driven-tf-module-release-flow.rego
@@ -1,12 +1,15 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # When attached to a module, this policy will trigger a tracked run when a tag event is detected.
 # It then parses the tag event data and uses that value for the module version.
 # Here, we remove a git tag prefixed with "v" as the Terraform Module Registry only supports versions in a numeric "X.X.X" format.
 
 module_version := trim_prefix(input.push.tag, "v")
 
-track {
+track if {
 	input.push.tag != ""
 }
 

--- a/examples/push/terragrunt-monorepo-ignore-changes-outside-root.rego
+++ b/examples/push/terragrunt-monorepo-ignore-changes-outside-root.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This example Git push policy ignores all changes that are outside a project's
 # root. Other than that, it follows the defaults - pushes to the tracked branch

--- a/examples/push/terragrunt-monorepo-ignore-changes-outside-root_test.rego
+++ b/examples/push/terragrunt-monorepo-ignore-changes-outside-root_test.rego
@@ -1,13 +1,12 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test tracking behavior
 test_track_valid_push if {
-	input := {
+	test_input := {
 		"push": {
 			"branch": "main",
 			"affected_files": ["project-root/main.tf"],
@@ -17,12 +16,12 @@ test_track_valid_push if {
 			"project_root": "project-root/",
 		},
 	}
-	spacelift.track with input as input
+	spacelift.track with input as test_input
 }
 
 # Test proposing behavior
 test_propose_valid_push if {
-	input := {
+	test_input := {
 		"push": {
 			"branch": "feature",
 			"affected_files": ["project-root/feature.tf"],
@@ -32,12 +31,12 @@ test_propose_valid_push if {
 			"project_root": "project-root/",
 		},
 	}
-	spacelift.propose with input as input
+	spacelift.propose with input as test_input
 }
 
 # Test ignoring behavior due to unaffected files
 test_ignore_unaffected_push if {
-	input := {
+	test_input := {
 		"push": {
 			"branch": "main",
 			"affected_files": ["unrelated-folder/unrelated-file.txt"],
@@ -47,12 +46,12 @@ test_ignore_unaffected_push if {
 			"project_root": "project-root/",
 		},
 	}
-	spacelift.ignore with input as input
+	spacelift.ignore with input as test_input
 }
 
 # Test ignoring behavior due to tag push
 test_ignore_tag_push if {
-	input := {
+	test_input := {
 		"push": {
 			"tag": "v1.0.0",
 			"affected_files": ["project-root/main.tf"],
@@ -62,5 +61,5 @@ test_ignore_tag_push if {
 			"project_root": "project-root/",
 		},
 	}
-	spacelift.ignore with input as input
+	spacelift.ignore with input as test_input
 }

--- a/examples/push/track-using-labels.rego
+++ b/examples/push/track-using-labels.rego
@@ -1,38 +1,41 @@
 package spacelift
 
-track {
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
+track if {
 	input.push.branch == input.stack.branch
 	affected
 }
 
-propose {
+propose if {
 	input.push.branch != ""
 }
 
-ignore {
+ignore if {
 	not affected
 }
 
 # Extract and use tracked directories and extensions from labels
-tracked_directories[tracked_directory] {
+tracked_directories contains tracked_directory if {
 	label := input.stack.labels[_]
 	startswith(label, "trackeddirectories:")
 	tracked_directory := split(label, ":")[1]
 }
 
-tracked_extensions[tracked_extension] {
+tracked_extensions contains tracked_extension if {
 	label := input.stack.labels[_]
 	startswith(label, "trackedextensions:")
 	tracked_extension := split(label, ":")[1]
 }
 
-affected {
+affected if {
 	some i, j
 	path := input.push.affected_files[i]
 	startswith(path, tracked_directories[j])
 }
 
-affected {
+affected if {
 	some i, j
 	path := input.push.affected_files[i]
 	endswith(path, tracked_extensions[j])

--- a/examples/push/track-using-labels_test.rego
+++ b/examples/push/track-using-labels_test.rego
@@ -1,4 +1,7 @@
-package spacelift
+package spacelift_test
+
+import data.spacelift
+import rego.v1
 
 # Mocked Data for Tests
 mock_push_affected := {"affected_files": ["tracked/file.txt", "untracked/file.txt"]}
@@ -10,64 +13,64 @@ mock_stack_labels_with_trackings := {"labels": ["trackeddirectories:tracked", "t
 # Tests
 
 # Test: track rule with different branches
-test_track_different_branches {
-	not track with input as {
+test_track_different_branches if {
+	not spacelift.track with input as {
 		"push": {"branch": "main"},
 		"stack": {"branch": "develop"},
 	}
 }
 
 # Test: propose rule with non-empty branch
-test_propose_non_empty_branch {
-	propose with input as {
+test_propose_non_empty_branch if {
+	spacelift.propose with input as {
 		"push": {"branch": "main"},
 		"stack": {},
 	}
 }
 
 # Test: propose rule with empty branch
-test_propose_empty_branch {
-	not propose with input as {
+test_propose_empty_branch if {
+	not spacelift.propose with input as {
 		"push": {"branch": ""},
 		"stack": {},
 	}
 }
 
 # Test: affected by directory path
-test_affected_directory {
-	affected with input as {
+test_affected_directory if {
+	spacelift.affected with input as {
 		"push": mock_push_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
 }
 
 # Test: affected by file extension
-test_affected_extension {
-	affected with input as {
+test_affected_extension if {
+	spacelift.affected with input as {
 		"push": mock_push_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
 }
 
 # Test: not track by directory path
-test_not_affected_directory {
-	not track with input as {
+test_not_affected_directory if {
+	not spacelift.track with input as {
 		"push": mock_push_not_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
 }
 
 # Test: not track by file extension
-test_not_affected_extension {
-	not track with input as {
+test_not_affected_extension if {
+	not spacelift.track with input as {
 		"push": mock_push_not_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}
 }
 
 # Test: track rule with not affected files
-test_ignore_not_affected {
-	not track with input as {
+test_ignore_not_affected if {
+	not spacelift.track with input as {
 		"push": mock_push_not_affected,
 		"stack": mock_stack_labels_with_trackings,
 	}

--- a/examples/trigger/advanced-automated-retries.rego
+++ b/examples/trigger/advanced-automated-retries.rego
@@ -1,5 +1,8 @@
 package spacelift
 
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
+
 # set the maximum number of retries
 default max_retries := 3
 
@@ -23,15 +26,15 @@ new_retries := max(obtain_retries_count(input.run.flags)) + 1
 
 retry_flag := sprintf("%s:%d", [retry_count_key, new_retries])
 
-flag[retry_flag]
+flag contains retry_flag
 
-is_failed_and_tracked {
+is_failed_and_tracked if {
 	input.run.state == "FAILED"
 	input.run.type == "TRACKED"
 }
 
 # trigger the stack if the max retry label is 0
-trigger[stack.id] {
+trigger contains stack.id if {
 	stack := input.stack
 	is_failed_and_tracked
 	retry_label <= 0
@@ -39,7 +42,7 @@ trigger[stack.id] {
 }
 
 # trigger the stack if the max retry label is defined but only up to the maximum retries
-trigger[stack.id] {
+trigger contains stack.id if {
 	stack := input.stack
 	is_failed_and_tracked
 	retry_label > 0

--- a/examples/trigger/advanced-automated-retries_test.rego
+++ b/examples/trigger/advanced-automated-retries_test.rego
@@ -1,9 +1,8 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test Case 1: Failed and Tracked Run without flags
 test_failed_and_tracked_run_without_flags if {

--- a/examples/trigger/automated-retries.rego
+++ b/examples/trigger/automated-retries.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # Sometimes Terraform or Pulumi deployments fail for a reason that has nothing to do
 # with the code - think eventual consistency between various cloud subsystems, transient

--- a/examples/trigger/automated-retries_test.rego
+++ b/examples/trigger/automated-retries_test.rego
@@ -1,9 +1,8 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test Case 1: Failed and Tracked Run Without Trigger
 test_failed_tracked_run_without_trigger if {

--- a/examples/trigger/trigger-dependencies-via-labels-with-state.rego
+++ b/examples/trigger/trigger-dependencies-via-labels-with-state.rego
@@ -10,8 +10,8 @@ import rego.v1
 # https://docs.spacelift.io/concepts/policy/trigger-policy
 
 trigger contains stack.id if {
-	some stack in input.stacks
 	input.run.type == "TRACKED"
+	some stack in input.stacks
 	some label in stack.labels
 	label == concat("", [
 		"depends-on:", input.stack.id,

--- a/examples/trigger/trigger-dependencies-via-labels-with-state.rego
+++ b/examples/trigger/trigger-dependencies-via-labels-with-state.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy will cause every stack that declares dependency on the current stack
 # and state to get triggered when the conditions are met.

--- a/examples/trigger/trigger-dependencies-via-labels-with-state_test.rego
+++ b/examples/trigger/trigger-dependencies-via-labels-with-state_test.rego
@@ -1,13 +1,11 @@
-package spacelift
+package spacelift_test
 
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+import rego.v1
 
 # Test Case 1: Dependency and State Match
 test_dependency_and_state_match if {
-	spacelift.trigger with input as {
+	spacelift.trigger["stack-two"] with input as {
 		"run": {
 			"state": "FINISHED",
 			"type": "TRACKED",

--- a/examples/trigger/trigger-dependencies-via-labels.rego
+++ b/examples/trigger/trigger-dependencies-via-labels.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This example trigger policy will cause every stack that declares dependency on
 # the current one to get triggered when the current one is successfully updated.

--- a/examples/trigger/trigger-dependencies-via-labels.rego
+++ b/examples/trigger/trigger-dependencies-via-labels.rego
@@ -10,8 +10,8 @@ import rego.v1
 # https://docs.spacelift.io/concepts/policy/trigger-policy
 
 trigger contains stack.id if {
-	some stack in input.stacks
 	input.run.state == "FINISHED"
+	some stack in input.stacks
 	some label in stack.labels
 	label == concat("", ["depends-on:", input.stack.id])
 }

--- a/examples/trigger/trigger-dependencies-via-labels_test.rego
+++ b/examples/trigger/trigger-dependencies-via-labels_test.rego
@@ -1,9 +1,8 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test when run is finished and dependent stack is present
 test_trigger_dependency_present if {

--- a/examples/trigger/trigger-hardcoded-dependencies.rego
+++ b/examples/trigger/trigger-hardcoded-dependencies.rego
@@ -1,8 +1,7 @@
 package spacelift
 
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
+# This import is required for Rego v0 compatibility and can be removed if you are only using Rego v1.
+import rego.v1
 
 # This policy triggers a predefined list of Stacks when a Run finishes successfully
 # to create a complex workflow that spans multiple Stacks.

--- a/examples/trigger/trigger-hardcoded-dependencies_test.rego
+++ b/examples/trigger/trigger-hardcoded-dependencies_test.rego
@@ -1,9 +1,8 @@
 package spacelift_test
 
+import rego.v1
+
 import data.spacelift
-import future.keywords.contains
-import future.keywords.if
-import future.keywords.in
 
 # Test setup for finished runs
 test_trigger_success if {


### PR DESCRIPTION
# Description of the change

This PR migrates all our policy templates to Rego v1 as we're adding support for it. By using `import rego.v1`, we can maintain backward compatibility with `v0` while using `v1` syntax. The import is a noop in `v1` and enables `v1` syntax when compiled as `v0`. This way we have a single template that works on both versions without duplicating everything.


Changes:
- Migrated all policy files to `v1` syntax with `import rego.v1`
- Updated Regal to the latest version in GitHub Actions
- Fixed code to address new Regal lints
- Ignored some non-critical new lints

Sorry for the size of this PR. I couldn't split it up without breaking CI checks since everything's interconnected.

## Checklist

Please make sure that the proposed change checks all the boxes below before requesting a review:

- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

If the proposed change is ready to be merged, please request a review from `@spacelift-io/solutions-engineering`. Someone will review and merge the pull request.

_Spacelift employees should request reviews from the relevant engineers and are allowed to merge pull requests after they got at least one approval._

Thank you for your contribution! 🙇
