### PR TITLE
feat: add MS Teams and Discord drift detection notification policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ _Access policies have been deprecated. Please [read this](examples/access/README
 ### Notification Policy
 
 - [Drift Detection with changes](examples/notification/drift-detection-with-changes.rego)
+- [MS Teams | Drift Detection with Changes](examples/notification/ms-teams-drift-detection-with-changes.rego)
+- [Discord | Drift Detection with Changes](examples/notification/discord-drift-detection-with-changes.rego)
 - [Slack Channels set with labels](examples/notification/slack-channels-with-labels.rego)
 - [Notification for link to failure logs](examples/notification/notification-failure.rego)
 - [Notification for Origins of Failed Stacks](examples/notification/notification-stack-failure-origins.rego)

--- a/examples/notification/discord-drift-detection-with-changes.rego
+++ b/examples/notification/discord-drift-detection-with-changes.rego
@@ -4,7 +4,7 @@ package spacelift
 webhook[wbdata] {
 	# 1. Identify the specific webhook
 	endpoint := input.webhook_endpoints[_]
-	endpoint.id == "kals-discord-notifications" # Change this to your discord webhook ID
+	endpoint.id == "discord-webhook" # Change this to your discord webhook ID
 
 	# 2. Extract stack and run info
 	stack := input.run_updated.stack
@@ -16,6 +16,7 @@ webhook[wbdata] {
 		"payload": {
 			"embeds": [{
 				"title": "Drift detected!",
+                # change your URL below to app.us.spacelift.io if you are using the US region or app.eu.spacelift.io if you are using the EU region
 				"description": sprintf("Stack: [%s](https://%s.app.spacelift.io/stack/%s)\nRun ID: [%s](https://%s.app.spacelift.io/stack/%s/run/%s)\nRun state: %s", [stack.name, input.account.name, stack.id, run.id, input.account.name, stack.id, run.id, run.state]),
 			}],
 		},

--- a/examples/notification/discord-drift-detection-with-changes.rego
+++ b/examples/notification/discord-drift-detection-with-changes.rego
@@ -1,0 +1,29 @@
+package spacelift
+
+# Send updates about tracked runs to discord.
+webhook[wbdata] {
+	# 1. Identify the specific webhook
+	endpoint := input.webhook_endpoints[_]
+	endpoint.id == "kals-discord-notifications" # Change this to your discord webhook ID
+
+	# 2. Extract stack and run info
+	stack := input.run_updated.stack
+	run := input.run_updated.run
+
+	# 3. Construct the payload
+	wbdata := {
+		"endpoint_id": endpoint.id,
+		"payload": {
+			"embeds": [{
+				"title": "Drift detected!",
+				"description": sprintf("Stack: [%s](https://%s.app.spacelift.io/stack/%s)\nRun ID: [%s](https://%s.app.spacelift.io/stack/%s/run/%s)\nRun state: %s", [stack.name, input.account.name, stack.id, run.id, input.account.name, stack.id, run.id, run.state]),
+			}],
+		},
+	}
+
+	# 4. Trigger logic: ONLY if drift is detected with more than 0 changes
+	input.run_updated.run.drift_detection
+	count(input.run_updated.run.changes) > 0
+}
+
+sample := true

--- a/examples/notification/discord-drift-detection-with-changes.yml
+++ b/examples/notification/discord-drift-detection-with-changes.yml
@@ -1,0 +1,11 @@
+name: "Discord | Drift Detection with Changes"
+source: discord-drift-detection-with-changes.rego
+type: notification
+description: |
+  This policy sends a notification to a Discord webhook when drift is detected on a stack and there are actual changes to be applied.
+  It sends a rich embed with links directly to the affected stack and run in Spacelift.
+labels:
+- notification
+- drift-detection
+- discord
+- webhook

--- a/examples/notification/discord-drift-detection-with-changes_test.rego
+++ b/examples/notification/discord-drift-detection-with-changes_test.rego
@@ -1,0 +1,37 @@
+package spacelift
+
+test_drift_detected_with_changes_discord {
+	webhook[payload] with input as {
+		"account": {"name": "test-account"},
+		"webhook_endpoints": [{"id": "kals-discord-notifications"}],
+		"run_updated": {
+			"stack": {"id": "test-stack", "name": "Test Stack"},
+			"run": {
+				"id": "test-run",
+				"state": "FINISHED",
+				"drift_detection": true,
+				"changes": [{"action": "added"}],
+			},
+		},
+	}
+
+	payload.endpoint_id == "kals-discord-notifications"
+	payload.payload.embeds[0].title == "Drift detected!"
+	contains(payload.payload.embeds[0].description, "test-account.app.spacelift.io")
+}
+
+test_no_drift_no_discord_webhook {
+	not webhook[_] with input as {
+		"account": {"name": "test-account"},
+		"webhook_endpoints": [{"id": "kals-discord-notifications"}],
+		"run_updated": {
+			"stack": {"id": "test-stack", "name": "Test Stack"},
+			"run": {
+				"id": "test-run",
+				"state": "FINISHED",
+				"drift_detection": false,
+				"changes": [{"action": "added"}],
+			},
+		},
+	}
+}

--- a/examples/notification/discord-drift-detection-with-changes_test.rego
+++ b/examples/notification/discord-drift-detection-with-changes_test.rego
@@ -3,7 +3,7 @@ package spacelift
 test_drift_detected_with_changes_discord {
 	webhook[payload] with input as {
 		"account": {"name": "test-account"},
-		"webhook_endpoints": [{"id": "kals-discord-notifications"}],
+		"webhook_endpoints": [{"id": "discord-webhook"}],
 		"run_updated": {
 			"stack": {"id": "test-stack", "name": "Test Stack"},
 			"run": {
@@ -15,7 +15,7 @@ test_drift_detected_with_changes_discord {
 		},
 	}
 
-	payload.endpoint_id == "kals-discord-notifications"
+	payload.endpoint_id == "discord-webhook"
 	payload.payload.embeds[0].title == "Drift detected!"
 	contains(payload.payload.embeds[0].description, "test-account.app.spacelift.io")
 }
@@ -23,7 +23,7 @@ test_drift_detected_with_changes_discord {
 test_no_drift_no_discord_webhook {
 	not webhook[_] with input as {
 		"account": {"name": "test-account"},
-		"webhook_endpoints": [{"id": "kals-discord-notifications"}],
+		"webhook_endpoints": [{"id": "discord-webhook"}],
 		"run_updated": {
 			"stack": {"id": "test-stack", "name": "Test Stack"},
 			"run": {

--- a/examples/notification/ms-teams-drift-detection-with-changes.rego
+++ b/examples/notification/ms-teams-drift-detection-with-changes.rego
@@ -3,7 +3,7 @@ package spacelift
 webhook[wbdata] {
 	# 1. Identify the specific webhook
 	endpoint := input.webhook_endpoints[_]
-	endpoint.id == "teams-webhook"
+	endpoint.id == "teams-webhook" # Change this to your webhook ID
 
 	# 2. Logic: Only trigger if drift is detected and there are changes
 	input.run_updated.run.drift_detection
@@ -44,6 +44,7 @@ webhook[wbdata] {
 					"actions": [{
 						"type": "Action.OpenUrl",
 						"title": "View in Spacelift",
+                        # change your URL below to app.us.spacelift.io if you are using the US region or app.eu.spacelift.io if you are using the EU region
 						"url": sprintf("https://%s.app.spacelift.io/stack/%s/run/%s", [input.account.name, stack.id, run.id]),
 					}],
 				},

--- a/examples/notification/ms-teams-drift-detection-with-changes.rego
+++ b/examples/notification/ms-teams-drift-detection-with-changes.rego
@@ -1,0 +1,55 @@
+package spacelift
+
+webhook[wbdata] {
+	# 1. Identify the specific webhook
+	endpoint := input.webhook_endpoints[_]
+	endpoint.id == "teams-webhook"
+
+	# 2. Logic: Only trigger if drift is detected and there are changes
+	input.run_updated.run.drift_detection
+	count(input.run_updated.run.changes) > 0
+
+	# 3. Helpers for readability
+	stack := input.run_updated.stack
+	run := input.run_updated.run
+
+	# 4. Construct the payload
+	wbdata := {
+		"endpoint_id": endpoint.id,
+		"payload": {
+			"type": "message",
+			"attachments": [{
+				"contentType": "application/vnd.microsoft.card.adaptive",
+				"content": {
+					"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+					"type": "AdaptiveCard",
+					"version": "1.2",
+					"body": [
+						{
+							"type": "TextBlock",
+							"size": "Large",
+							"weight": "Bolder",
+							"text": "🔄 Drift Detected",
+							"wrap": true,
+						},
+						{
+							"type": "FactSet",
+							"facts": [
+								{"title": "Stack", "value": stack.name},
+								{"title": "State", "value": run.state},
+								{"title": "Changes", "value": sprintf("%d resource(s)", [count(run.changes)])},
+							],
+						},
+					],
+					"actions": [{
+						"type": "Action.OpenUrl",
+						"title": "View in Spacelift",
+						"url": sprintf("https://%s.app.spacelift.io/stack/%s/run/%s", [input.account.name, stack.id, run.id]),
+					}],
+				},
+			}],
+		},
+	}
+}
+
+sample := true

--- a/examples/notification/ms-teams-drift-detection-with-changes.yml
+++ b/examples/notification/ms-teams-drift-detection-with-changes.yml
@@ -1,0 +1,11 @@
+name: "MS Teams | Drift Detection with Changes"
+source: ms-teams-drift-detection-with-changes.rego
+type: notification
+description: |
+  This policy sends a notification to a Microsoft Teams webhook when drift is detected on a stack and there are actual changes to be applied.
+  It uses an Adaptive Card to provide a rich visual summary of the drift, including the stack name, current state, and the number of resources affected.
+labels:
+- notification
+- drift-detection
+- ms-teams
+- webhook

--- a/examples/notification/ms-teams-drift-detection-with-changes_test.rego
+++ b/examples/notification/ms-teams-drift-detection-with-changes_test.rego
@@ -1,0 +1,52 @@
+package spacelift
+
+test_drift_detected_with_changes {
+	webhook[payload] with input as {
+		"account": {"name": "test-account"},
+		"webhook_endpoints": [{"id": "teams-webhook"}],
+		"run_updated": {
+			"stack": {"id": "test-stack", "name": "Test Stack"},
+			"run": {
+				"id": "test-run",
+				"state": "FINISHED",
+				"drift_detection": true,
+				"changes": [{"action": "added"}],
+			},
+		},
+	}
+
+	payload.endpoint_id == "teams-webhook"
+	payload.payload.attachments[0].content.body[0].text == "🔄 Drift Detected"
+}
+
+test_no_drift_no_webhook {
+	not webhook[_] with input as {
+		"account": {"name": "test-account"},
+		"webhook_endpoints": [{"id": "teams-webhook"}],
+		"run_updated": {
+			"stack": {"id": "test-stack", "name": "Test Stack"},
+			"run": {
+				"id": "test-run",
+				"state": "FINISHED",
+				"drift_detection": false,
+				"changes": [{"action": "added"}],
+			},
+		},
+	}
+}
+
+test_drift_no_changes_no_webhook {
+	not webhook[_] with input as {
+		"account": {"name": "test-account"},
+		"webhook_endpoints": [{"id": "teams-webhook"}],
+		"run_updated": {
+			"stack": {"id": "test-stack", "name": "Test Stack"},
+			"run": {
+				"id": "test-run",
+				"state": "FINISHED",
+				"drift_detection": true,
+				"changes": [],
+			},
+		},
+	}
+}


### PR DESCRIPTION
# Description of the change

This PR adds two new notification policies to the Spacelift policy library for **Microsoft Teams** and **Discord**. 
These policies alert teams when **Drift is detected** on a stack and there are actionable changes. They provide rich visual summaries (Adaptive Cards for Teams, Embeds for Discord) and direct links to the stacks and runs to streamline the reconciliation process.
### Policies Added:
1. **MS Teams | Drift Detection with Changes**: Sends an Adaptive Card with stack details and change counts.
2. **Discord | Drift Detection with Changes**: Sends a rich embed with formatted links.
### Key Improvements:
* Used `input.account.name` for dynamic link generation (works across any Spacelift organization).
* Added comments for region-specific URL adjustments (`app.us.spacelift.io` vs `app.eu.spacelift.io`).
* Included full REGO test suites for both policies.
## Checklist
- [x] Each new policy has corresponding tests.
- [x] All the tests pass.
- [x] The pull request is opened against the `main` branch.
- [x] The pull request is no longer marked as a draft.
- [x] You agree to license your contribution under the [MIT license](https://github.com/spacelift-io/spacelift-policies-example-library/blob/main/LICENSE) to Spacelift (not required for Spacelift employees).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds new example policies and tests plus README links; no existing policy behavior is modified beyond documentation indexing.
> 
> **Overview**
> Adds two new Notification Policy examples that post webhook messages to **Microsoft Teams** (Adaptive Card) and **Discord** (embed) when a tracked run reports drift *and* `count(changes) > 0`, including deep links to the affected stack/run.
> 
> Updates `README.md` to list the new examples, and adds corresponding `.yml` metadata plus Rego test suites to validate both the positive trigger and "no drift / no changes" non-trigger behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44d79bc96afd3069111add467824b58dc9062a87. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->