### PR TITLE
ci: add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      gomod:
+        patterns:
+          - "*"


### PR DESCRIPTION
Enables Dependabot in this repo, which currently has no config.

Configured for the ecosystems actually present here, with updates grouped per ecosystem to keep PR volume manageable, running **daily**.

Matches the house style used across the `terraform-*-selfhosted` repos (grouped `patterns: ["*"]` per ecosystem).